### PR TITLE
Add Firestore integration

### DIFF
--- a/lib/add_inventory_page.dart
+++ b/lib/add_inventory_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 class AddInventoryPage extends StatefulWidget {
   const AddInventoryPage({super.key});
@@ -14,6 +15,17 @@ class _AddInventoryPageState extends State<AddInventoryPage> {
   int _quantity = 1;
   String _unit = '個';
   String _note = '';
+
+  Future<void> _saveItem() async {
+    await FirebaseFirestore.instance.collection('inventory').add({
+      'itemName': _itemName,
+      'category': _category,
+      'quantity': _quantity,
+      'unit': _unit,
+      'note': _note,
+      'createdAt': Timestamp.now(),
+    });
+  }
 
   final List<String> _categories = ['冷蔵庫', '冷凍庫', '日用品'];
   final List<String> _units = ['個', '本', '袋', 'ロール'];
@@ -78,10 +90,10 @@ class _AddInventoryPageState extends State<AddInventoryPage> {
               ElevatedButton.icon(
                 icon: const Icon(Icons.save),
                 label: const Text('保存'),
-                onPressed: () {
+                onPressed: () async {
                   if (_formKey.currentState!.validate()) {
-                    // TODO: 登録処理（FireStoreや状態管理と連携）
-                    Navigator.pop(context);
+                    await _saveItem();
+                    if (mounted) Navigator.pop(context);
                   }
                 },
               ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,12 +34,12 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  firebase_core: ^2.25.0
+  cloud_firestore: ^4.14.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  firebase_core: ^2.25.0
-  cloud_firestore: ^4.14.0
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is
   # activated in the `analysis_options.yaml` file located at the root of your


### PR DESCRIPTION
## Summary
- wire up Firebase initialization in `main.dart`
- save inventory to Firestore from AddInventoryPage
- read inventory from Firestore in HomePage
- include Firestore packages in pubspec

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart format -o none --set-exit-if-changed lib/add_inventory_page.dart lib/main.dart pubspec.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d4935d634832ea1b7f43c08a77670