### PR TITLE
Add feedback for inventory save

### DIFF
--- a/lib/add_inventory_page.dart
+++ b/lib/add_inventory_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_core/firebase_core.dart';
 
 class AddInventoryPage extends StatefulWidget {
   const AddInventoryPage({super.key});
@@ -92,8 +93,32 @@ class _AddInventoryPageState extends State<AddInventoryPage> {
                 label: const Text('保存'),
                 onPressed: () async {
                   if (_formKey.currentState!.validate()) {
-                    await _saveItem();
-                    if (mounted) Navigator.pop(context);
+                    try {
+                      await _saveItem();
+                      if (!mounted) return;
+                      final snackBar = ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('保存完了')),
+                      );
+                      await snackBar.closed;
+                      if (!mounted) return;
+                      Navigator.pop(context);
+                    } on FirebaseException catch (e) {
+                      if (mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Text(
+                              '保存に失敗しました: ${e.message ?? e.code}',
+                            ),
+                          ),
+                        );
+                      }
+                    } catch (_) {
+                      if (mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('保存に失敗しました')),
+                        );
+                      }
+                    }
                   }
                 },
               ),


### PR DESCRIPTION
## Summary
- show a snackbar when saving inventory succeeds before closing the page
- notify user of Firestore errors on save

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d52a80778832e98e5a11257bcff54