### PR TITLE
Improve error reporting in inventory stream

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,13 +41,14 @@ class HomePage extends StatelessWidget {
             .collection('inventory')
             .orderBy('createdAt', descending: true)
             .snapshots(),
-        builder: (context, snapshot) {
-          if (snapshot.hasError) {
-            return const Center(child: Text('読み込みエラー'));
-          }
-          if (!snapshot.hasData) {
-            return const Center(child: CircularProgressIndicator());
-          }
+          builder: (context, snapshot) {
+            if (snapshot.hasError) {
+              final errorMessage = snapshot.error?.toString() ?? '不明なエラー';
+              return Center(child: Text('読み込みエラー: $errorMessage'));
+            }
+            if (!snapshot.hasData) {
+              return const Center(child: CircularProgressIndicator());
+            }
           final docs = snapshot.data!.docs;
           return ListView(
             padding: const EdgeInsets.all(16),


### PR DESCRIPTION
## Summary
- show Firestore error message on main page instead of generic load error

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d519faec4832e911ef6969c9335cc