### PR TITLE
Add inventory management features with history

### DIFF
--- a/lib/add_inventory_page.dart
+++ b/lib/add_inventory_page.dart
@@ -18,8 +18,8 @@ class _AddInventoryPageState extends State<AddInventoryPage> {
   String _itemName = '';
   // カテゴリ
   String _category = '日用品';
-  // 数量
-  int _quantity = 1;
+  // 数量（小数点第一位まで扱う）
+  double _quantity = 1.0;
   // 単位
   String _unit = '個';
   // 任意のメモ
@@ -27,13 +27,18 @@ class _AddInventoryPageState extends State<AddInventoryPage> {
 
   // 入力内容を Firestore に保存する
   Future<void> _saveItem() async {
-    await FirebaseFirestore.instance.collection('inventory').add({
+    final doc = await FirebaseFirestore.instance.collection('inventory').add({
       'itemName': _itemName,
       'category': _category,
       'quantity': _quantity,
       'unit': _unit,
       'note': _note,
       'createdAt': Timestamp.now(),
+    });
+    await doc.collection('history').add({
+      'type': 'add',
+      'quantity': _quantity,
+      'timestamp': Timestamp.now(),
     });
   }
 
@@ -77,16 +82,18 @@ class _AddInventoryPageState extends State<AddInventoryPage> {
                   IconButton(
                     icon: const Icon(Icons.remove),
                     onPressed: () => setState(() {
-                      // 数量を減らす
-                      if (_quantity > 1) _quantity--;
+                      // 数量を0.1単位で減らす
+                      if (_quantity > 0.1) _quantity -= 0.1;
+                      _quantity = double.parse(_quantity.toStringAsFixed(1));
                     }),
                   ),
-                  Text('$_quantity'),
+                  Text(_quantity.toStringAsFixed(1)),
                   IconButton(
                     icon: const Icon(Icons.add),
                     onPressed: () => setState(() {
-                      // 数量を増やす
-                      _quantity++;
+                      // 数量を0.1単位で増やす
+                      _quantity += 0.1;
+                      _quantity = double.parse(_quantity.toStringAsFixed(1));
                     }),
                   ),
                 ],

--- a/lib/inventory_detail_page.dart
+++ b/lib/inventory_detail_page.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+// 履歴データを保持するクラス
+class HistoryEntry {
+  final String type;
+  final double quantity;
+  final Timestamp timestamp;
+
+  HistoryEntry(this.type, this.quantity, this.timestamp);
+}
+
+// 購入予測アルゴリズムの Strategy インターフェイス
+abstract class PurchasePredictionStrategy {
+  DateTime predict(DateTime now, List<HistoryEntry> history, double quantity);
+}
+
+// 現状は仮の実装。常に一週間後を返す
+class DummyPredictionStrategy implements PurchasePredictionStrategy {
+  const DummyPredictionStrategy();
+  @override
+  DateTime predict(DateTime now, List<HistoryEntry> history, double quantity) {
+    return now.add(const Duration(days: 7));
+  }
+}
+
+// 商品詳細画面。履歴と予測日を表示する
+class InventoryDetailPage extends StatelessWidget {
+  final DocumentReference<Map<String, dynamic>> docRef;
+  final String itemName;
+  final String unit;
+  final PurchasePredictionStrategy strategy;
+
+  const InventoryDetailPage({
+    super.key,
+    required this.docRef,
+    required this.itemName,
+    required this.unit,
+    this.strategy = const DummyPredictionStrategy(),
+  });
+
+  Stream<List<HistoryEntry>> historyStream() {
+    return docRef
+        .collection('history')
+        .orderBy('timestamp', descending: true)
+        .snapshots()
+        .map((snapshot) => snapshot.docs
+            .map((d) => HistoryEntry(
+                  d['type'] ?? '',
+                  (d['quantity'] ?? 0).toDouble(),
+                  d['timestamp'] as Timestamp,
+                ))
+            .toList());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(itemName)),
+      body: StreamBuilder<List<HistoryEntry>>(
+        stream: historyStream(),
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final list = snapshot.data!;
+          final predicted =
+              strategy.predict(DateTime.now(), list, _currentQuantity(list));
+          return ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              Text('次回購入予測: ${_formatDate(predicted)}'),
+              const SizedBox(height: 16),
+              const Text('履歴', style: TextStyle(fontSize: 18)),
+              ...list.map((e) => ListTile(
+                    title: Text('${e.quantity.toStringAsFixed(1)}$unit'),
+                    subtitle: Text(_formatDate(e.timestamp.toDate())),
+                  )),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  double _currentQuantity(List<HistoryEntry> history) {
+    if (history.isEmpty) return 0;
+    double total = 0;
+    for (final h in history) {
+      if (h.type == 'add' || h.type == 'bought') {
+        total += h.quantity;
+      } else if (h.type == 'used' || h.type == 'stocktake') {
+        total -= h.quantity;
+      }
+    }
+    return total;
+  }
+
+  String _formatDate(DateTime date) {
+    return '${date.year}/${date.month}/${date.day}';
+  }
+}

--- a/lib/stocktake_page.dart
+++ b/lib/stocktake_page.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+// 棚卸入力用のデータ保持クラス
+class _StockItem {
+  final DocumentReference<Map<String, dynamic>> ref;
+  final String name;
+  final TextEditingController controller;
+
+  _StockItem(this.ref, this.name, double quantity)
+      : controller = TextEditingController(text: quantity.toStringAsFixed(1));
+}
+
+// 棚卸画面
+class StocktakePage extends StatefulWidget {
+  const StocktakePage({super.key});
+
+  @override
+  State<StocktakePage> createState() => _StocktakePageState();
+}
+
+class _StocktakePageState extends State<StocktakePage> {
+  final List<_StockItem> _items = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final snapshot = await FirebaseFirestore.instance
+        .collection('inventory')
+        .orderBy('createdAt')
+        .get();
+    setState(() {
+      _items.clear();
+      for (final doc in snapshot.docs) {
+        final q = (doc['quantity'] ?? 0).toDouble();
+        final name = doc['itemName'] ?? doc.id;
+        _items.add(_StockItem(doc.reference, name, q));
+      }
+    });
+  }
+
+  Future<void> _save() async {
+    for (final item in _items) {
+      final value = double.tryParse(item.controller.text) ?? 0;
+      await item.ref.update({'quantity': value});
+      await item.ref.collection('history').add({
+        'type': 'stocktake',
+        'quantity': value,
+        'timestamp': Timestamp.now(),
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('棚卸入力')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          for (final item in _items)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: TextField(
+                controller: item.controller,
+                keyboardType:
+                    const TextInputType.numberWithOptions(decimal: true),
+                decoration: InputDecoration(labelText: item.name),
+              ),
+            ),
+          ElevatedButton(
+            onPressed: () async {
+              await _save();
+              if (mounted) Navigator.pop(context);
+            },
+            child: const Text('保存'),
+          )
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- allow decimal quantities on inventory items
- record history when creating items
- provide product detail and stocktaking screens
- handle inventory updates with dialogs
- add menu actions for new screens

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d88f95f3c832e8467e44dd639fd6a