### PR TITLE
Add widget tests

### DIFF
--- a/test/add_inventory_page_test.dart
+++ b/test/add_inventory_page_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:oouchi_stock/add_inventory_page.dart';
+
+void main() {
+  // 加減ボタンを押した際に数量が変化するかを確認するテスト
+  testWidgets('数量の増減テスト', (WidgetTester tester) async {
+    // AddInventoryPage を MaterialApp でラップして表示
+    await tester.pumpWidget(const MaterialApp(home: AddInventoryPage()));
+
+    // 初期状態では数量 1.0 が表示されているはず
+    expect(find.text('1.0'), findsOneWidget);
+
+    // プラスボタンをタップして 1.1 になるか確認
+    await tester.tap(find.widgetWithIcon(IconButton, Icons.add));
+    await tester.pump();
+    expect(find.text('1.1'), findsOneWidget);
+
+    // マイナスボタンをタップして 1.0 に戻るか確認
+    await tester.tap(find.widgetWithIcon(IconButton, Icons.remove));
+    await tester.pump();
+    expect(find.text('1.0'), findsOneWidget);
+  });
+}

--- a/test/purchase_prediction_test.dart
+++ b/test/purchase_prediction_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oouchi_stock/inventory_detail_page.dart';
+
+void main() {
+  // ダミー予測戦略の戻り値を確認するテスト
+  test('DummyPredictionStrategy は常に 7 日後を返す', () {
+    // 現在時刻を固定
+    final now = DateTime(2023, 1, 1);
+    // ダミー戦略インスタンス
+    const strategy = DummyPredictionStrategy();
+    // 予測結果を取得
+    final result = strategy.predict(now, const [], 0);
+    // 期待される日時
+    final expected = now.add(const Duration(days: 7));
+    // 結果が期待通りか確認
+    expect(result, expected);
+  });
+}


### PR DESCRIPTION
## Summary
- add widget test for AddInventoryPage
- add unit test for DummyPredictionStrategy

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd4f56cb0832ea4f0a7378684e94a