### PR TITLE
Fix const constructor for MyApp

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,11 +14,12 @@ void main() async {
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   ); // Firebase の初期設定
-  runApp(MyApp()); // アプリのスタート
+  runApp(const MyApp()); // アプリのスタート
 }
 
 // アプリのルートウィジェット
 class MyApp extends StatelessWidget {
+  const MyApp({super.key});
   @override
   Widget build(BuildContext context) {
     return MaterialApp(


### PR DESCRIPTION
## Summary
- add a const constructor for `MyApp`
- use the const constructor when starting the app

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684ddd0e2850832ea2e1debeebe92838