### PR TITLE
Initialize Firebase in widget test

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -9,8 +9,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:oouchi_stock/main.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:oouchi_stock/firebase_options.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+  });
+
   testWidgets('アプリが起動する', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
     expect(find.text('おうちストック'), findsOneWidget);


### PR DESCRIPTION
## Summary
- ensure widget tests initialize Firebase before running

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ddd4c18f8832ea3dfd1865c8944ac