### PR TITLE
Add Firestore index configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ flutterfire configure
 - `FIREBASE_OPTIONS` : `firebase_options.dart` へのパス
 - `GOOGLE_APPLICATION_CREDENTIALS` : サービスアカウント認証情報の JSON ファイル
 
+## Firestore のインデックス
+
+一部のクエリでは複合インデックスが必要となります。リポジトリには
+`firestore.indexes.json` を含めているので、初回セットアップ時に次のコマンドで
+デプロイしてください。
+
+```bash
+firebase deploy --only firestore:indexes
+```
+
+Firestore コンソールから手動で作成しても構いません。
+
 ## 実行手順
 
 次のコマンドを順に実行してアプリを起動します。

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,13 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "inventory",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "category", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}


### PR DESCRIPTION
## Summary
- add `firestore.indexes.json` for Firestore composite index
- document index deployment in README

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684ddda3875c832ead666b21e7be06fa