### PR TITLE
Fix Firebase init in tests

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -10,10 +10,12 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:oouchi_stock/main.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
 import 'package:oouchi_stock/firebase_options.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+  setupFirebaseCoreMocks();
 
   setUpAll(() async {
     await Firebase.initializeApp(


### PR DESCRIPTION
## Summary
- ensure Firebase mocks are setup in widget tests to avoid channel errors

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dde2ded4c832e99bf3935c2d7fca6