### PR TITLE
Fix NDK version for Firebase

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -11,7 +11,8 @@ plugins {
 android {
     namespace = "com.example.oouchi_stock"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    // Override Flutter's default NDK version to satisfy Firebase libraries
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
## Summary
- set the Android NDK version to `27.0.12077973` for Firebase plugins

## Testing
- `flutter analyze` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684dded5cdc4832eafd5b59664c366ea