### PR TITLE
Fix Firestore index instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ firebase deploy --only firestore:indexes
 
 Firestore コンソールから手動で作成しても構いません。
 
+実行時に `FAILED_PRECONDITION: The query requires an index` のエラーが表示された
+場合は、インデックスがまだデプロイされていない可能性があります。上記コマンドを
+実行するか、表示される URL からインデックスを作成してください。
+
 ## 実行手順
 
 次のコマンドを順に実行してアプリを起動します。

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -5,7 +5,8 @@
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "category", "order": "ASCENDING" },
-        { "fieldPath": "createdAt", "order": "DESCENDING" }
+        { "fieldPath": "createdAt", "order": "DESCENDING" },
+        { "fieldPath": "__name__", "order": "DESCENDING" }
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- include `__name__` in Firestore composite index
- document how to fix `FAILED_PRECONDITION` index errors

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ddec4a33c832e946fc0901ef11ad6