### PR TITLE
Fix Firebase mocks for tests

### DIFF
--- a/test/firebase_test_utils.dart
+++ b/test/firebase_test_utils.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/services.dart';
+import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
+
+/// Simple mock setup for Firebase to allow [Firebase.initializeApp] in tests.
+Future<void> setupFirebaseCoreMocks() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const MethodChannel channel = MethodChannel('plugins.flutter.io/firebase_core');
+
+  channel.setMockMethodCallHandler((MethodCall methodCall) async {
+    switch (methodCall.method) {
+      case 'Firebase#initializeCore':
+        return [
+          {
+            'name': defaultFirebaseAppName,
+            'options': defaultFirebaseOptions,
+          }
+        ];
+      case 'Firebase#initializeApp':
+        return {
+          'name': methodCall.arguments['appName'] ?? defaultFirebaseAppName,
+          'options': defaultFirebaseOptions,
+          'pluginConstants': <String, dynamic>{},
+        };
+      default:
+        return null;
+    }
+  });
+}
+
+const defaultFirebaseOptions = <String, String>{
+  'apiKey': 'testApiKey',
+  'appId': '1:123:android:123',
+  'messagingSenderId': '123',
+  'projectId': 'test',
+};

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -11,9 +11,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:oouchi_stock/main.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:oouchi_stock/firebase_options.dart';
+import 'firebase_test_utils.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+  setupFirebaseCoreMocks();
 
   setUpAll(() async {
     await Firebase.initializeApp(


### PR DESCRIPTION
## Summary
- add custom Firebase mock helper for tests
- use helper in widget test to init Firebase

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dde2ded4c832e99bf3935c2d7fca6