### PR TITLE
Fix Google Play services check

### DIFF
--- a/android/app/src/main/kotlin/com/example/oouchi_stock/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/oouchi_stock/MainActivity.kt
@@ -3,6 +3,7 @@ package com.example.oouchi_stock
 import android.content.Intent
 import android.os.Bundle
 import com.google.android.gms.common.GoogleApiAvailability
+import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.security.ProviderInstaller
 import io.flutter.embedding.android.FlutterActivity
 
@@ -10,8 +11,18 @@ class MainActivity : FlutterActivity(), ProviderInstaller.ProviderInstallListene
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // Ensure Google Play services' security provider is installed.
-        ProviderInstaller.installIfNeededAsync(this, this)
+        // Ensure Google Play services' security provider is installed when
+        // Google Play services is available on the device. Some emulator
+        // images do not include Play services and calling
+        // ProviderInstaller without this check results in a
+        // SecurityException.
+        val availability = GoogleApiAvailability.getInstance()
+        val result = availability.isGooglePlayServicesAvailable(this)
+        if (result == ConnectionResult.SUCCESS) {
+            ProviderInstaller.installIfNeededAsync(this, this)
+        } else if (availability.isUserResolvableError(result)) {
+            availability.showErrorDialogFragment(this, result, 0)
+        }
     }
 
     override fun onProviderInstalled() {


### PR DESCRIPTION
## Summary
- handle absent Google Play services when initializing the security provider

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e9e2efb1c832eb2a50297e7761ebc