### PR TITLE
Add settings and editing features

### DIFF
--- a/lib/add_inventory_page.dart
+++ b/lib/add_inventory_page.dart
@@ -4,7 +4,7 @@ import 'domain/entities/inventory.dart';
 import 'domain/usecases/add_inventory.dart';
 import 'data/repositories/inventory_repository_impl.dart';
 
-// 在庫を追加する画面のウィジェット
+// 商品を追加する画面のウィジェット
 
 class AddInventoryPage extends StatefulWidget {
   const AddInventoryPage({super.key});
@@ -78,7 +78,7 @@ class _AddInventoryPageState extends State<AddInventoryPage> {
   Widget build(BuildContext context) {
     // 画面のレイアウトを構築
     return Scaffold(
-      appBar: AppBar(title: const Text('在庫を追加')),
+      appBar: AppBar(title: const Text('商品を追加')),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Form(

--- a/lib/data/repositories/inventory_repository_impl.dart
+++ b/lib/data/repositories/inventory_repository_impl.dart
@@ -83,6 +83,17 @@ class InventoryRepositoryImpl implements InventoryRepository {
   }
 
   @override
+  Future<void> updateInventory(Inventory inventory) async {
+    await _firestore.collection('inventory').doc(inventory.id).update({
+      'itemName': inventory.itemName,
+      'category': inventory.category,
+      'itemType': inventory.itemType,
+      'unit': inventory.unit,
+      'note': inventory.note,
+    });
+  }
+
+  @override
   Stream<List<HistoryEntry>> watchHistory(String inventoryId) {
     return _firestore
         .collection('inventory')

--- a/lib/domain/repositories/inventory_repository.dart
+++ b/lib/domain/repositories/inventory_repository.dart
@@ -10,6 +10,8 @@ abstract class InventoryRepository {
 
   Future<void> updateQuantity(String id, double amount, String type);
 
+  Future<void> updateInventory(Inventory inventory);
+
   Stream<List<HistoryEntry>> watchHistory(String inventoryId);
 
   Future<void> stocktake(

--- a/lib/domain/usecases/update_inventory.dart
+++ b/lib/domain/usecases/update_inventory.dart
@@ -1,0 +1,11 @@
+import '../entities/inventory.dart';
+import '../repositories/inventory_repository.dart';
+
+class UpdateInventory {
+  final InventoryRepository repository;
+  UpdateInventory(this.repository);
+
+  Future<void> call(Inventory inventory) async {
+    await repository.updateInventory(inventory);
+  }
+}

--- a/lib/edit_inventory_page.dart
+++ b/lib/edit_inventory_page.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'domain/entities/inventory.dart';
+import 'domain/usecases/update_inventory.dart';
+import 'data/repositories/inventory_repository_impl.dart';
+
+class EditInventoryPage extends StatefulWidget {
+  final String id;
+  final String itemName;
+  final String category;
+  final String itemType;
+  final String unit;
+  final String note;
+  const EditInventoryPage({
+    super.key,
+    required this.id,
+    required this.itemName,
+    required this.category,
+    required this.itemType,
+    required this.unit,
+    required this.note,
+  });
+
+  @override
+  State<EditInventoryPage> createState() => _EditInventoryPageState();
+}
+
+class _EditInventoryPageState extends State<EditInventoryPage> {
+  final _formKey = GlobalKey<FormState>();
+  late String _itemName;
+  late String _category;
+  late String _itemType;
+  late String _unit;
+  late String _note;
+
+  final UpdateInventory _usecase =
+      UpdateInventory(InventoryRepositoryImpl());
+
+  final List<String> _categories = ['冷蔵庫', '冷凍庫', '日用品'];
+  final Map<String, List<String>> _typesMap = {
+    '冷蔵庫': ['その他'],
+    '冷凍庫': ['その他'],
+    '日用品': ['柔軟剤', '洗濯洗剤', '食洗器洗剤', '衣料用漂白剤']
+  };
+  final List<String> _units = ['個', '本', '袋', 'ロール'];
+
+  @override
+  void initState() {
+    super.initState();
+    _itemName = widget.itemName;
+    _category = widget.category;
+    _itemType = widget.itemType;
+    _unit = widget.unit;
+    _note = widget.note;
+  }
+
+  Future<void> _saveItem() async {
+    final item = Inventory(
+      id: widget.id,
+      itemName: _itemName,
+      category: _category,
+      itemType: _itemType,
+      quantity: 0,
+      unit: _unit,
+      note: _note,
+      createdAt: DateTime.now(),
+    );
+    await _usecase(item);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('商品編集')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: ListView(
+            children: [
+              TextFormField(
+                initialValue: _itemName,
+                decoration: const InputDecoration(labelText: '商品名'),
+                onChanged: (v) => _itemName = v,
+                validator: (v) =>
+                    v == null || v.isEmpty ? '商品名は必須です' : null,
+              ),
+              const SizedBox(height: 12),
+              DropdownButtonFormField<String>(
+                decoration: const InputDecoration(labelText: 'カテゴリ'),
+                value: _category,
+                items: _categories
+                    .map((c) => DropdownMenuItem(value: c, child: Text(c)))
+                    .toList(),
+                onChanged: (v) {
+                  if (v == null) return;
+                  setState(() {
+                    _category = v;
+                    final types = _typesMap[v];
+                    if (types != null && types.isNotEmpty) {
+                      _itemType = types.first;
+                    }
+                  });
+                },
+              ),
+              const SizedBox(height: 12),
+              DropdownButtonFormField<String>(
+                decoration: const InputDecoration(labelText: '品種'),
+                value: _itemType,
+                items: (_typesMap[_category] ?? ['その他'])
+                    .map((t) => DropdownMenuItem(value: t, child: Text(t)))
+                    .toList(),
+                onChanged: (v) => setState(() => _itemType = v ?? ''),
+              ),
+              const SizedBox(height: 12),
+              DropdownButtonFormField<String>(
+                decoration: const InputDecoration(labelText: '単位'),
+                value: _unit,
+                items:
+                    _units.map((u) => DropdownMenuItem(value: u, child: Text(u))).toList(),
+                onChanged: (v) => setState(() => _unit = v ?? ''),
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                initialValue: _note,
+                decoration: const InputDecoration(labelText: 'メモ'),
+                onChanged: (v) => _note = v,
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton.icon(
+                icon: const Icon(Icons.save),
+                label: const Text('保存'),
+                onPressed: () async {
+                  if (_formKey.currentState!.validate()) {
+                    await _saveItem();
+                    if (mounted) Navigator.pop(context);
+                  }
+                },
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/inventory_detail_page.dart
+++ b/lib/inventory_detail_page.dart
@@ -3,6 +3,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'data/repositories/inventory_repository_impl.dart';
 import 'domain/entities/history_entry.dart';
 import 'domain/services/purchase_prediction_strategy.dart';
+import 'edit_inventory_page.dart';
 
 
 // 商品詳細画面。履歴と予測日を表示する
@@ -10,6 +11,9 @@ class InventoryDetailPage extends StatelessWidget {
   final String inventoryId;
   final String itemName;
   final String unit;
+  final String category;
+  final String itemType;
+  final double quantity;
   final PurchasePredictionStrategy strategy;
   final InventoryRepositoryImpl repository = InventoryRepositoryImpl();
 
@@ -18,6 +22,9 @@ class InventoryDetailPage extends StatelessWidget {
     required this.inventoryId,
     required this.itemName,
     required this.unit,
+    required this.category,
+    required this.itemType,
+    required this.quantity,
     this.strategy = const DummyPredictionStrategy(),
   });
 
@@ -28,7 +35,26 @@ class InventoryDetailPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(itemName)),
+      appBar: AppBar(title: Text(itemName), actions: [
+        IconButton(
+          icon: const Icon(Icons.edit),
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => EditInventoryPage(
+                  id: inventoryId,
+                  itemName: itemName,
+                  category: category,
+                  itemType: itemType,
+                  unit: unit,
+                  note: '',
+                ),
+              ),
+            );
+          },
+        )
+      ]),
       body: StreamBuilder<List<HistoryEntry>>(
         stream: historyStream(),
         builder: (context, snapshot) {
@@ -41,10 +67,19 @@ class InventoryDetailPage extends StatelessWidget {
           return ListView(
             padding: const EdgeInsets.all(16),
             children: [
+              Text('カテゴリ: $category'),
+              Text('品種: $itemType'),
+              Text('在庫: ${quantity.toStringAsFixed(1)}$unit'),
+              const SizedBox(height: 8),
               Text('次回購入予測: ${_formatDate(predicted)}'),
               const SizedBox(height: 16),
               const Text('履歴', style: TextStyle(fontSize: 18)),
-              ...list.map(_buildHistoryTile),
+              SizedBox(
+                height: MediaQuery.of(context).size.height / 3,
+                child: ListView(
+                  children: list.map(_buildHistoryTile).toList(),
+                ),
+              ),
             ],
           );
         },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'add_inventory_page.dart';
 import 'add_category_page.dart';
+import 'settings_page.dart';
 import 'inventory_detail_page.dart';
 import 'stocktake_page.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -39,20 +40,29 @@ class MyApp extends StatelessWidget {
 }
 
 // 在庫一覧を表示する画面
-class HomePage extends StatelessWidget {
+class HomePage extends StatefulWidget {
   const HomePage({super.key});
 
-  static const List<String> categories = ['冷蔵庫', '冷凍庫', '日用品'];
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  List<String> _categories = ['冷蔵庫', '冷凍庫', '日用品'];
+
+  void _updateCategories(List<String> list) {
+    setState(() => _categories = List.from(list));
+  }
 
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
-      length: categories.length,
+      length: _categories.length,
       child: Scaffold(
         appBar: AppBar(
           title: const Text('おうちストック'),
           centerTitle: true,
-          bottom: TabBar(tabs: [for (final c in categories) Tab(text: c)]),
+          bottom: TabBar(tabs: [for (final c in _categories) Tab(text: c)]),
           actions: [
             PopupMenuButton<String>(
               onSelected: (value) {
@@ -71,18 +81,36 @@ class HomePage extends StatelessWidget {
                     context,
                     MaterialPageRoute(builder: (c) => const AddCategoryPage()),
                   );
+                } else if (value == 'settings') {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (c) => SettingsPage(
+                              categories: _categories,
+                              onReorder: _updateCategories,
+                            )),
+                  );
                 }
               },
               itemBuilder: (context) => [
-                const PopupMenuItem(value: 'add', child: Text('在庫を追加')),
-                const PopupMenuItem(value: 'stock', child: Text('棚卸入力')),
-                const PopupMenuItem(value: 'category', child: Text('カテゴリ追加')),
+                const PopupMenuItem(
+                    value: 'add',
+                    child: Text('商品を追加', style: TextStyle(fontSize: 18))),
+                const PopupMenuItem(
+                    value: 'stock',
+                    child: Text('棚卸入力', style: TextStyle(fontSize: 18))),
+                const PopupMenuItem(
+                    value: 'category',
+                    child: Text('カテゴリ追加', style: TextStyle(fontSize: 18))),
+                const PopupMenuItem(
+                    value: 'settings',
+                    child: Text('設定', style: TextStyle(fontSize: 18))),
               ],
             )
           ],
         ),
         body: TabBarView(
-          children: [for (final c in categories) InventoryList(category: c)],
+          children: [for (final c in _categories) InventoryList(category: c)],
         ),
         floatingActionButton: FloatingActionButton(
           onPressed: () {
@@ -129,6 +157,9 @@ class InventoryList extends StatelessWidget {
                       inventoryId: inv.id,
                       itemName: inv.itemName,
                       unit: inv.unit,
+                      category: inv.category,
+                      itemType: inv.itemType,
+                      quantity: inv.quantity,
                     ),
                   ),
                 );
@@ -260,10 +291,14 @@ class InventoryCard extends StatelessWidget {
                     Text('${inventory.itemType} / ${inventory.itemName}',
                         style: const TextStyle(fontSize: 18)),
                     const SizedBox(height: 4),
-                    Text('${inventory.quantity.toStringAsFixed(1)}${inventory.unit}',
-                        style: const TextStyle(color: Colors.grey)),
-                    Text('予測: $dateText',
-                        style: const TextStyle(color: Colors.grey)),
+                    Text(
+                      '${inventory.quantity.toStringAsFixed(1)}${inventory.unit}',
+                      style: const TextStyle(color: Colors.black87),
+                    ),
+                    Text(
+                      '予測: $dateText',
+                      style: const TextStyle(color: Colors.black87),
+                    ),
                   ],
                 ),
                 Row(

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'add_category_page.dart';
+
+class SettingsPage extends StatelessWidget {
+  final List<String> categories;
+  final ValueChanged<List<String>> onReorder;
+  const SettingsPage({
+    super.key,
+    required this.categories,
+    required this.onReorder,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('設定')),
+      body: ListView(
+        children: [
+          ListTile(
+            title: const Text('カテゴリ追加'),
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const AddCategoryPage()),
+            ),
+          ),
+          ListTile(
+            title: const Text('タグ並び替え'),
+            onTap: () async {
+              final result = await Navigator.push<List<String>>(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => TagOrderPage(initial: categories),
+                ),
+              );
+              if (result != null) onReorder(result);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class TagOrderPage extends StatefulWidget {
+  final List<String> initial;
+  const TagOrderPage({super.key, required this.initial});
+
+  @override
+  State<TagOrderPage> createState() => _TagOrderPageState();
+}
+
+class _TagOrderPageState extends State<TagOrderPage> {
+  late List<String> _list;
+
+  @override
+  void initState() {
+    super.initState();
+    _list = List.from(widget.initial);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('タグ並び替え')),
+      body: ReorderableListView(
+        onReorder: (oldIndex, newIndex) {
+          setState(() {
+            if (newIndex > oldIndex) newIndex -= 1;
+            final item = _list.removeAt(oldIndex);
+            _list.insert(newIndex, item);
+          });
+        },
+        children: [
+          for (final c in _list)
+            ListTile(key: ValueKey(c), title: Text(c)),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => Navigator.pop(context, _list),
+        child: const Icon(Icons.save),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- allow editing of inventory items
- darken quantity and prediction text on inventory cards
- add Settings and tag ordering
- add update inventory use case
- show more info on detail page and limit history view
- rename "在庫を追加" to "商品を追加"

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ea71ec218832ea11435fc2c4d98bc