### PR TITLE
Fix inventory detail updates after edit

### DIFF
--- a/lib/data/repositories/inventory_repository_impl.dart
+++ b/lib/data/repositories/inventory_repository_impl.dart
@@ -94,6 +94,28 @@ class InventoryRepositoryImpl implements InventoryRepository {
   }
 
   @override
+  Stream<Inventory?> watchInventory(String inventoryId) {
+    return _firestore
+        .collection('inventory')
+        .doc(inventoryId)
+        .snapshots()
+        .map((doc) {
+      final data = doc.data();
+      if (data == null) return null;
+      return Inventory(
+        id: doc.id,
+        itemName: data['itemName'] ?? '',
+        category: data['category'] ?? '',
+        itemType: data['itemType'] ?? '',
+        quantity: (data['quantity'] ?? 0).toDouble(),
+        unit: data['unit'] ?? '',
+        note: data['note'] ?? '',
+        createdAt: (data['createdAt'] as Timestamp).toDate(),
+      );
+    });
+  }
+
+  @override
   Stream<List<HistoryEntry>> watchHistory(String inventoryId) {
     return _firestore
         .collection('inventory')

--- a/lib/domain/repositories/inventory_repository.dart
+++ b/lib/domain/repositories/inventory_repository.dart
@@ -12,6 +12,9 @@ abstract class InventoryRepository {
 
   Future<void> updateInventory(Inventory inventory);
 
+  /// 指定IDの在庫情報をストリームで取得する
+  Stream<Inventory?> watchInventory(String inventoryId);
+
   Stream<List<HistoryEntry>> watchHistory(String inventoryId);
 
   Future<void> stocktake(

--- a/lib/domain/usecases/watch_inventory.dart
+++ b/lib/domain/usecases/watch_inventory.dart
@@ -1,0 +1,11 @@
+import '../entities/inventory.dart';
+import '../repositories/inventory_repository.dart';
+
+class WatchInventory {
+  final InventoryRepository repository;
+  WatchInventory(this.repository);
+
+  Stream<Inventory?> call(String id) {
+    return repository.watchInventory(id);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -155,11 +155,6 @@ class InventoryList extends StatelessWidget {
                   MaterialPageRoute(
                     builder: (_) => InventoryDetailPage(
                       inventoryId: inv.id,
-                      itemName: inv.itemName,
-                      unit: inv.unit,
-                      category: inv.category,
-                      itemType: inv.itemType,
-                      quantity: inv.quantity,
                     ),
                   ),
                 );


### PR DESCRIPTION
## Summary
- watch single inventory documents to keep detail page in sync
- expose `watchInventory` in repository layer
- update inventory detail page to use the new stream
- adjust main screen navigation accordingly

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685005399bd4832ebcfdf664868bdacd