### PR TITLE
Update text for category reorder

### DIFF
--- a/lib/add_category_page.dart
+++ b/lib/add_category_page.dart
@@ -24,7 +24,7 @@ class _AddCategoryPageState extends State<AddCategoryPage> {
       await ScaffoldMessenger.of(context)
           .showSnackBar(const SnackBar(content: Text('保存しました')))
           .closed;
-      if (mounted) Navigator.pop(context);
+      if (mounted) Navigator.pop(context, _name);
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -77,10 +77,13 @@ class _HomePageState extends State<HomePage> {
                     MaterialPageRoute(builder: (c) => const StocktakePage()),
                   );
                 } else if (value == 'category') {
-                  Navigator.push(
+                  final newCategory = await Navigator.push<String>(
                     context,
                     MaterialPageRoute(builder: (c) => const AddCategoryPage()),
                   );
+                  if (newCategory != null) {
+                    _updateCategories([..._categories, newCategory]);
+                  }
                 } else if (value == 'settings') {
                   Navigator.push(
                     context,

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -18,18 +18,24 @@ class SettingsPage extends StatelessWidget {
         children: [
           ListTile(
             title: const Text('カテゴリ追加'),
-            onTap: () => Navigator.push(
-              context,
-              MaterialPageRoute(builder: (_) => const AddCategoryPage()),
-            ),
+            onTap: () async {
+              final newCategory = await Navigator.push<String>(
+                context,
+                MaterialPageRoute(builder: (_) => const AddCategoryPage()),
+              );
+              if (newCategory != null) {
+                final updated = List<String>.from(categories)..add(newCategory);
+                onReorder(updated);
+              }
+            },
           ),
           ListTile(
-            title: const Text('タグ並び替え'),
+            title: const Text('カテゴリ並び替え'),
             onTap: () async {
               final result = await Navigator.push<List<String>>(
                 context,
                 MaterialPageRoute(
-                  builder: (_) => TagOrderPage(initial: categories),
+                  builder: (_) => CategoryOrderPage(initial: categories),
                 ),
               );
               if (result != null) onReorder(result);
@@ -41,15 +47,15 @@ class SettingsPage extends StatelessWidget {
   }
 }
 
-class TagOrderPage extends StatefulWidget {
+class CategoryOrderPage extends StatefulWidget {
   final List<String> initial;
-  const TagOrderPage({super.key, required this.initial});
+  const CategoryOrderPage({super.key, required this.initial});
 
   @override
-  State<TagOrderPage> createState() => _TagOrderPageState();
+  State<CategoryOrderPage> createState() => _CategoryOrderPageState();
 }
 
-class _TagOrderPageState extends State<TagOrderPage> {
+class _CategoryOrderPageState extends State<CategoryOrderPage> {
   late List<String> _list;
 
   @override
@@ -61,7 +67,7 @@ class _TagOrderPageState extends State<TagOrderPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('タグ並び替え')),
+      appBar: AppBar(title: const Text('カテゴリ並び替え')),
       body: ReorderableListView(
         onReorder: (oldIndex, newIndex) {
           setState(() {


### PR DESCRIPTION
## Summary
- update Settings page labels from `タグ並び替え` to `カテゴリ並び替え`
- return new category name when saving so tabs update automatically
- add newly created categories to tabs in Home and Settings pages
- rename `TagOrderPage` to `CategoryOrderPage`

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685004795008832eb3fce05c7c63a4cc