### PR TITLE
Fix popup menu async error

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -77,13 +77,14 @@ class _HomePageState extends State<HomePage> {
                     MaterialPageRoute(builder: (c) => const StocktakePage()),
                   );
                 } else if (value == 'category') {
-                  final newCategory = await Navigator.push<String>(
+                  Navigator.push<String>(
                     context,
                     MaterialPageRoute(builder: (c) => const AddCategoryPage()),
-                  );
-                  if (newCategory != null) {
-                    _updateCategories([..._categories, newCategory]);
-                  }
+                  ).then((newCategory) {
+                    if (newCategory != null) {
+                      _updateCategories([..._categories, newCategory]);
+                    }
+                  });
                 } else if (value == 'settings') {
                   Navigator.push(
                     context,


### PR DESCRIPTION
## Summary
- handle popup menu navigator result using `.then` instead of `await`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850068f9e78832e87993d591211fa67