### PR TITLE
Fix missing import for edit page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'add_inventory_page.dart';
 import 'settings_page.dart';
 import 'inventory_detail_page.dart';
 import 'stocktake_page.dart';
+import 'edit_inventory_page.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'firebase_options.dart'; // ← 自動生成された設定ファイル


### PR DESCRIPTION
## Summary
- add the missing `edit_inventory_page.dart` import

## Testing
- `flutter format lib/main.dart` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850103bfdac832eb8115a2c3f7835ad