### PR TITLE
Implement category settings with reorder/add/delete

### DIFF
--- a/lib/category_settings_page.dart
+++ b/lib/category_settings_page.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'add_category_page.dart';
+
+/// カテゴリを一覧表示し並び替えや追加・削除を行う画面。
+class CategorySettingsPage extends StatefulWidget {
+  final List<String> initial;
+  final ValueChanged<List<String>> onChanged;
+  const CategorySettingsPage({
+    super.key,
+    required this.initial,
+    required this.onChanged,
+  });
+
+  @override
+  State<CategorySettingsPage> createState() => _CategorySettingsPageState();
+}
+
+class _CategorySettingsPageState extends State<CategorySettingsPage> {
+  late List<String> _list;
+
+  @override
+  void initState() {
+    super.initState();
+    _list = List.from(widget.initial);
+  }
+
+  Future<void> _deleteCategory(String name) async {
+    try {
+      final snapshot = await FirebaseFirestore.instance
+          .collection('categories')
+          .where('name', isEqualTo: name)
+          .get();
+      for (final doc in snapshot.docs) {
+        await doc.reference.delete();
+      }
+      if (mounted) {
+        setState(() => _list.remove(name));
+        widget.onChanged(List.from(_list));
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('削除しました')));
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('削除に失敗しました')));
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('カテゴリ設定')),
+      body: ReorderableListView(
+        onReorder: (oldIndex, newIndex) {
+          setState(() {
+            if (newIndex > oldIndex) newIndex -= 1;
+            final item = _list.removeAt(oldIndex);
+            _list.insert(newIndex, item);
+          });
+          widget.onChanged(List.from(_list));
+        },
+        children: [
+          for (final c in _list)
+            ListTile(
+              key: ValueKey(c),
+              title: Text(c),
+              trailing: IconButton(
+                icon: const Icon(Icons.delete),
+                onPressed: () async {
+                  final ok = await showDialog<bool>(
+                    context: context,
+                    builder: (context) => AlertDialog(
+                      content: Text('「$c」を削除しますか？'),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.pop(context, false),
+                          child: const Text('キャンセル'),
+                        ),
+                        TextButton(
+                          onPressed: () => Navigator.pop(context, true),
+                          child: const Text('削除'),
+                        ),
+                      ],
+                    ),
+                  );
+                  if (ok == true) {
+                    _deleteCategory(c);
+                  }
+                },
+              ),
+            ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          final newCategory = await Navigator.push<String>(
+            context,
+            MaterialPageRoute(builder: (_) => const AddCategoryPage()),
+          );
+          if (newCategory != null) {
+            setState(() => _list.add(newCategory));
+            widget.onChanged(List.from(_list));
+          }
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -122,7 +122,7 @@ class _HomePageState extends State<HomePage> {
                     MaterialPageRoute(
                         builder: (c) => SettingsPage(
                               categories: _categories,
-                              onReorder: _updateCategories,
+                              onChanged: _updateCategories,
                             )),
                   );
                 }

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
-import 'add_category_page.dart';
+import 'category_settings_page.dart';
 
 class SettingsPage extends StatelessWidget {
   final List<String> categories;
-  final ValueChanged<List<String>> onReorder;
+  final ValueChanged<List<String>> onChanged;
   const SettingsPage({
     super.key,
     required this.categories,
-    required this.onReorder,
+    required this.onChanged,
   });
 
   @override
@@ -17,28 +17,17 @@ class SettingsPage extends StatelessWidget {
       body: ListView(
         children: [
           ListTile(
-            title: const Text('カテゴリ追加'),
-            onTap: () async {
-              final newCategory = await Navigator.push<String>(
-                context,
-                MaterialPageRoute(builder: (_) => const AddCategoryPage()),
-              );
-              if (newCategory != null) {
-                final updated = List<String>.from(categories)..add(newCategory);
-                onReorder(updated);
-              }
-            },
-          ),
-          ListTile(
-            title: const Text('カテゴリ並び替え'),
-            onTap: () async {
-              final result = await Navigator.push<List<String>>(
+            title: const Text('カテゴリ設定'),
+            onTap: () {
+              Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (_) => CategoryOrderPage(initial: categories),
+                  builder: (_) => CategorySettingsPage(
+                    initial: categories,
+                    onChanged: onChanged,
+                  ),
                 ),
               );
-              if (result != null) onReorder(result);
             },
           ),
         ],
@@ -47,44 +36,3 @@ class SettingsPage extends StatelessWidget {
   }
 }
 
-class CategoryOrderPage extends StatefulWidget {
-  final List<String> initial;
-  const CategoryOrderPage({super.key, required this.initial});
-
-  @override
-  State<CategoryOrderPage> createState() => _CategoryOrderPageState();
-}
-
-class _CategoryOrderPageState extends State<CategoryOrderPage> {
-  late List<String> _list;
-
-  @override
-  void initState() {
-    super.initState();
-    _list = List.from(widget.initial);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('カテゴリ並び替え')),
-      body: ReorderableListView(
-        onReorder: (oldIndex, newIndex) {
-          setState(() {
-            if (newIndex > oldIndex) newIndex -= 1;
-            final item = _list.removeAt(oldIndex);
-            _list.insert(newIndex, item);
-          });
-        },
-        children: [
-          for (final c in _list)
-            ListTile(key: ValueKey(c), title: Text(c)),
-        ],
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () => Navigator.pop(context, _list),
-        child: const Icon(Icons.save),
-      ),
-    );
-  }
-}


### PR DESCRIPTION
## Summary
- add a new `CategorySettingsPage` for listing, reordering, adding and deleting categories
- update `SettingsPage` to open the new page
- pass category updates using `onChanged` callback

## Testing
- `flutter --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68501150fd74832e835b0178c66aae9d