### PR TITLE
Fix firebase test utils import

### DIFF
--- a/test/firebase_test_utils.dart
+++ b/test/firebase_test_utils.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
 
 /// Simple mock setup for Firebase to allow [Firebase.initializeApp] in tests.


### PR DESCRIPTION
## Summary
- fix missing import in `test/firebase_test_utils.dart`

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685011ed94d4832e94e7f9599c5b9e95