### PR TITLE
Fix widget tests without Firebase

### DIFF
--- a/lib/add_inventory_page.dart
+++ b/lib/add_inventory_page.dart
@@ -9,7 +9,8 @@ import 'data/repositories/inventory_repository_impl.dart';
 // 商品を追加する画面のウィジェット
 
 class AddInventoryPage extends StatefulWidget {
-  const AddInventoryPage({super.key});
+  final List<String>? categories;
+  const AddInventoryPage({super.key, this.categories});
 
   @override
   State<AddInventoryPage> createState() => _AddInventoryPageState();
@@ -51,8 +52,7 @@ class _AddInventoryPageState extends State<AddInventoryPage> {
 
   // カテゴリの選択肢
   List<String> _categories = [];
-  late final StreamSubscription<QuerySnapshot<Map<String, dynamic>>>
-      _catSub;
+  StreamSubscription<QuerySnapshot<Map<String, dynamic>>>? _catSub;
   // カテゴリごとの品種一覧
   final Map<String, List<String>> _typesMap = {
     '冷蔵庫': ['その他'],
@@ -81,24 +81,28 @@ class _AddInventoryPageState extends State<AddInventoryPage> {
   @override
   void initState() {
     super.initState();
-    _catSub = FirebaseFirestore.instance
-        .collection('categories')
-        .orderBy('createdAt')
-        .snapshots()
-        .listen((snapshot) {
-      setState(() {
-        _categories =
-            snapshot.docs.map((d) => d.data()['name'] as String).toList();
-        if (_categories.isNotEmpty && !_categories.contains(_category)) {
-          _category = _categories.first;
-        }
+    if (widget.categories != null) {
+      _categories = List.from(widget.categories!);
+    } else {
+      _catSub = FirebaseFirestore.instance
+          .collection('categories')
+          .orderBy('createdAt')
+          .snapshots()
+          .listen((snapshot) {
+        setState(() {
+          _categories =
+              snapshot.docs.map((d) => d.data()['name'] as String).toList();
+          if (_categories.isNotEmpty && !_categories.contains(_category)) {
+            _category = _categories.first;
+          }
+        });
       });
-    });
+    }
   }
 
   @override
   void dispose() {
-    _catSub.cancel();
+    _catSub?.cancel();
     super.dispose();
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,7 +28,8 @@ void main() async {
 
 // アプリのルートウィジェット
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  final List<String>? initialCategories;
+  const MyApp({super.key, this.initialCategories});
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -37,14 +38,15 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.teal),
         useMaterial3: true,
       ),
-      home: const HomePage(),
+      home: HomePage(categories: initialCategories),
     );
   }
 }
 
 // 在庫一覧を表示する画面
 class HomePage extends StatefulWidget {
-  const HomePage({super.key});
+  final List<String>? categories;
+  const HomePage({super.key, this.categories});
 
   @override
   State<HomePage> createState() => _HomePageState();
@@ -52,7 +54,7 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   List<String> _categories = [];
-  late final StreamSubscription<QuerySnapshot<Map<String, dynamic>>> _catSub;
+  StreamSubscription<QuerySnapshot<Map<String, dynamic>>>? _catSub;
 
   void _updateCategories(List<String> list) {
     setState(() => _categories = List.from(list));
@@ -61,21 +63,25 @@ class _HomePageState extends State<HomePage> {
   @override
   void initState() {
     super.initState();
-    _catSub = FirebaseFirestore.instance
-        .collection('categories')
-        .orderBy('createdAt')
-        .snapshots()
-        .listen((snapshot) {
-      setState(() {
-        _categories =
-            snapshot.docs.map((d) => d.data()['name'] as String).toList();
+    if (widget.categories != null) {
+      _categories = List.from(widget.categories!);
+    } else {
+      _catSub = FirebaseFirestore.instance
+          .collection('categories')
+          .orderBy('createdAt')
+          .snapshots()
+          .listen((snapshot) {
+        setState(() {
+          _categories =
+              snapshot.docs.map((d) => d.data()['name'] as String).toList();
+        });
       });
-    });
+    }
   }
 
   @override
   void dispose() {
-    _catSub.cancel();
+    _catSub?.cancel();
     super.dispose();
   }
 

--- a/test/add_inventory_page_test.dart
+++ b/test/add_inventory_page_test.dart
@@ -7,7 +7,8 @@ void main() {
   // 加減ボタンを押した際に数量が変化するかを確認するテスト
   testWidgets('数量の増減テスト', (WidgetTester tester) async {
     // AddInventoryPage を MaterialApp でラップして表示
-    await tester.pumpWidget(const MaterialApp(home: AddInventoryPage()));
+    await tester.pumpWidget(
+        const MaterialApp(home: AddInventoryPage(categories: ['日用品'])));
 
     // 初期状態では数量 1.0 が表示されているはず
     expect(find.text('1.0'), findsOneWidget);

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -9,24 +9,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:oouchi_stock/main.dart';
-import 'package:firebase_core/firebase_core.dart';
-import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
-import 'package:oouchi_stock/firebase_options.dart';
 import 'firebase_test_utils.dart';
 import 'package:oouchi_stock/add_category_page.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
-  setupFirebaseCoreMocks();
-
-  setUpAll(() async {
-    await Firebase.initializeApp(
-      options: DefaultFirebaseOptions.currentPlatform,
-    );
-  });
 
   testWidgets('アプリが起動する', (WidgetTester tester) async {
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(
+        const MyApp(initialCategories: ['日用品']));
     expect(find.text('おうちストック'), findsOneWidget);
   });
 


### PR DESCRIPTION
## Summary
- make `AddInventoryPage` and `HomePage` accept optional category lists
- pass given categories from `MyApp`
- update tests to provide categories so Firebase isn't required

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685013104d1c832ebb324c8700f94ebc