### PR TITLE
Introduce 32‑bit IDs for categories

### DIFF
--- a/lib/add_category_page.dart
+++ b/lib/add_category_page.dart
@@ -1,3 +1,4 @@
+import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
@@ -17,14 +18,15 @@ class _AddCategoryPageState extends State<AddCategoryPage> {
   /// カテゴリを保存する処理。失敗時は SnackBar で通知する。
   Future<void> _save() async {
     try {
+      final id = Random().nextInt(0xffffffff);
       await FirebaseFirestore.instance
           .collection('categories')
-          .add({'name': _name, 'createdAt': Timestamp.now()});
+          .add({'id': id, 'name': _name, 'createdAt': Timestamp.now()});
       if (!mounted) return;
       await ScaffoldMessenger.of(context)
           .showSnackBar(const SnackBar(content: Text('保存しました')))
           .closed;
-      if (mounted) Navigator.pop(context, _name);
+      if (mounted) Navigator.pop(context);
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context)

--- a/lib/domain/entities/category.dart
+++ b/lib/domain/entities/category.dart
@@ -1,0 +1,7 @@
+class Category {
+  final int id;
+  final String name;
+  final DateTime createdAt;
+
+  Category({required this.id, required this.name, required this.createdAt});
+}

--- a/lib/edit_category_page.dart
+++ b/lib/edit_category_page.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
+import 'domain/entities/category.dart';
+
 /// カテゴリ名を編集する画面。
 class EditCategoryPage extends StatefulWidget {
-  final String initialName;
-  const EditCategoryPage({super.key, required this.initialName});
+  final Category category;
+  const EditCategoryPage({super.key, required this.category});
 
   @override
   State<EditCategoryPage> createState() => _EditCategoryPageState();
@@ -17,14 +19,14 @@ class _EditCategoryPageState extends State<EditCategoryPage> {
   @override
   void initState() {
     super.initState();
-    _name = widget.initialName;
+    _name = widget.category.name;
   }
 
   Future<void> _save() async {
     try {
       final snapshot = await FirebaseFirestore.instance
           .collection('categories')
-          .where('name', isEqualTo: widget.initialName)
+          .where('id', isEqualTo: widget.category.id)
           .get();
       for (final doc in snapshot.docs) {
         await doc.reference.update({'name': _name});

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -123,7 +123,9 @@ class _HomePageState extends State<HomePage> {
                   Navigator.push(
                     context,
                     MaterialPageRoute(
-                        builder: (c) => AddInventoryPage(categories: _categories)),
+                      builder: (_) =>
+                          AddInventoryPage(categories: _categories),
+                    ),
                   );
                 } else if (value == 'stock') {
                   Navigator.push(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'firebase_options.dart'; // ← 自動生成された設定ファイル
 import 'data/repositories/inventory_repository_impl.dart';
 import 'domain/entities/inventory.dart';
 import 'domain/entities/history_entry.dart';
+import 'domain/entities/category.dart';
 import 'domain/services/purchase_prediction_strategy.dart';
 import 'domain/usecases/watch_inventories.dart';
 import 'domain/usecases/update_quantity.dart';
@@ -28,7 +29,7 @@ void main() async {
 
 // アプリのルートウィジェット
 class MyApp extends StatelessWidget {
-  final List<String>? initialCategories;
+  final List<Category>? initialCategories;
   const MyApp({super.key, this.initialCategories});
   @override
   Widget build(BuildContext context) {
@@ -45,7 +46,7 @@ class MyApp extends StatelessWidget {
 
 // 在庫一覧を表示する画面
 class HomePage extends StatefulWidget {
-  final List<String>? categories;
+  final List<Category>? categories;
   const HomePage({super.key, this.categories});
 
   @override
@@ -53,10 +54,10 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
-  List<String> _categories = [];
+  List<Category> _categories = [];
   StreamSubscription<QuerySnapshot<Map<String, dynamic>>>? _catSub;
 
-  void _updateCategories(List<String> list) {
+  void _updateCategories(List<Category> list) {
     setState(() => _categories = List.from(list));
   }
 
@@ -72,8 +73,14 @@ class _HomePageState extends State<HomePage> {
           .snapshots()
           .listen((snapshot) {
         setState(() {
-          _categories =
-              snapshot.docs.map((d) => d.data()['name'] as String).toList();
+          _categories = snapshot.docs.map((d) {
+            final data = d.data();
+            return Category(
+              id: data['id'] ?? 0,
+              name: data['name'] ?? '',
+              createdAt: (data['createdAt'] as Timestamp).toDate(),
+            );
+          }).toList();
         });
       });
     }
@@ -105,7 +112,7 @@ class _HomePageState extends State<HomePage> {
               for (final c in _categories)
                 SizedBox(
                   width: MediaQuery.of(context).size.width / 3,
-                  child: Tab(text: c),
+                  child: Tab(text: c.name),
                 )
             ],
           ),
@@ -115,7 +122,8 @@ class _HomePageState extends State<HomePage> {
                 if (value == 'add') {
                   Navigator.push(
                     context,
-                    MaterialPageRoute(builder: (c) => const AddInventoryPage()),
+                    MaterialPageRoute(
+                        builder: (c) => AddInventoryPage(categories: _categories)),
                   );
                 } else if (value == 'stock') {
                   Navigator.push(
@@ -148,7 +156,10 @@ class _HomePageState extends State<HomePage> {
           ],
         ),
         body: TabBarView(
-          children: [for (final c in _categories) InventoryList(category: c)],
+          children: [
+            for (final c in _categories)
+              InventoryList(category: c.name, categories: _categories)
+          ],
         ),
         // 在庫一覧から商品を追加する機能はメニューからのみ利用するため
         // ここで表示していた追加用の FAB は削除する。
@@ -160,7 +171,8 @@ class _HomePageState extends State<HomePage> {
 /// 指定カテゴリの在庫を一覧表示するウィジェット。
 class InventoryList extends StatelessWidget {
   final String category;
-  const InventoryList({super.key, required this.category});
+  final List<Category> categories;
+  const InventoryList({super.key, required this.category, required this.categories});
 
   @override
   Widget build(BuildContext context) {
@@ -229,7 +241,13 @@ class InventoryList extends StatelessWidget {
                       builder: (_) => EditInventoryPage(
                         id: inv.id,
                         itemName: inv.itemName,
-                        category: inv.category,
+                        category: categories.firstWhere(
+                          (e) => e.name == inv.category,
+                          orElse: () => Category(
+                              id: 0,
+                              name: inv.category,
+                              createdAt: DateTime.now()),
+                        ),
                         itemType: inv.itemType,
                         unit: inv.unit,
                         note: inv.note,

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import 'category_settings_page.dart';
+import 'domain/entities/category.dart';
 
 class SettingsPage extends StatelessWidget {
-  final List<String> categories;
-  final ValueChanged<List<String>> onChanged;
+  final List<Category> categories;
+  final ValueChanged<List<Category>> onChanged;
   const SettingsPage({
     super.key,
     required this.categories,

--- a/test/add_inventory_page_test.dart
+++ b/test/add_inventory_page_test.dart
@@ -2,13 +2,19 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:oouchi_stock/add_inventory_page.dart';
+import 'package:oouchi_stock/domain/entities/category.dart';
 
 void main() {
   // 加減ボタンを押した際に数量が変化するかを確認するテスト
   testWidgets('数量の増減テスト', (WidgetTester tester) async {
     // AddInventoryPage を MaterialApp でラップして表示
     await tester.pumpWidget(
-        const MaterialApp(home: AddInventoryPage(categories: ['日用品'])));
+      MaterialApp(
+        home: AddInventoryPage(
+          categories: [Category(id: 1, name: '日用品', createdAt: DateTime.now())],
+        ),
+      ),
+    );
 
     // 初期状態では数量 1.0 が表示されているはず
     expect(find.text('1.0'), findsOneWidget);


### PR DESCRIPTION
## Summary
- add `Category` entity with 32-bit `id`
- generate IDs when saving categories and update edit/delete logic
- update pages and tests to use `Category` objects

## Testing
- `flutter test` *(fails: command not found)*
- `dart format -o none --set-exit-if-changed .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68501acc9c34832eb91ee543148ac14d