### PR TITLE
Fix category type mismatch

### DIFF
--- a/lib/inventory_detail_page.dart
+++ b/lib/inventory_detail_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'data/repositories/inventory_repository_impl.dart';
 import 'domain/entities/history_entry.dart';
 import 'domain/entities/inventory.dart';
+import 'domain/entities/category.dart';
 import 'domain/services/purchase_prediction_strategy.dart';
 import 'edit_inventory_page.dart';
 
@@ -9,12 +10,14 @@ import 'edit_inventory_page.dart';
 // 商品詳細画面。履歴と予測日を表示する
 class InventoryDetailPage extends StatelessWidget {
   final String inventoryId;
+  final List<Category> categories;
   final PurchasePredictionStrategy strategy;
   final InventoryRepositoryImpl repository = InventoryRepositoryImpl();
 
   InventoryDetailPage({
     super.key,
     required this.inventoryId,
+    required this.categories,
     this.strategy = const DummyPredictionStrategy(),
   });
 
@@ -48,7 +51,14 @@ class InventoryDetailPage extends StatelessWidget {
                     builder: (_) => EditInventoryPage(
                       id: inventoryId,
                       itemName: inv.itemName,
-                      category: inv.category,
+                      category: categories.firstWhere(
+                        (e) => e.name == inv.category,
+                        orElse: () => Category(
+                          id: 0,
+                          name: inv.category,
+                          createdAt: DateTime.now(),
+                        ),
+                      ),
                       itemType: inv.itemType,
                       unit: inv.unit,
                       note: inv.note,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -55,11 +55,11 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
-  List<String> _categories = [];
+  List<Category> _categories = [];
   bool _categoriesLoaded = false;
   StreamSubscription<QuerySnapshot<Map<String, dynamic>>>? _catSub;
 
-  void _updateCategories(List<String> list) {
+  void _updateCategories(List<Category> list) {
     setState(() {
       _categories = List.from(list);
       _categoriesLoaded = true;
@@ -223,6 +223,7 @@ class InventoryList extends StatelessWidget {
                   MaterialPageRoute(
                     builder: (_) => InventoryDetailPage(
                       inventoryId: inv.id,
+                      categories: categories,
                     ),
                   ),
                 );


### PR DESCRIPTION
## Summary
- fix `List<Category>` usage across widgets
- pass category objects to `InventoryDetailPage` and `EditInventoryPage`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68501f3af764832ea43adc3b892d1b0e