### PR TITLE
Fix inventory screen loading

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -87,6 +87,7 @@ class _HomePageState extends State<HomePage> {
               createdAt: (data['createdAt'] as Timestamp).toDate(),
             );
           }).toList();
+          _categoriesLoaded = true;
         });
       });
     }


### PR DESCRIPTION
## Summary
- ensure `_categoriesLoaded` is set after fetching categories

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850204401b8832eb2bc60a8d3db4186