### PR TITLE
Implement price management feature

### DIFF
--- a/lib/add_price_page.dart
+++ b/lib/add_price_page.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+
+import 'data/repositories/inventory_repository_impl.dart';
+import 'data/repositories/price_repository_impl.dart';
+import 'domain/entities/inventory.dart';
+import 'domain/entities/price_info.dart';
+import 'domain/usecases/add_price_info.dart';
+import 'domain/usecases/fetch_all_inventory.dart';
+
+class AddPricePage extends StatefulWidget {
+  const AddPricePage({super.key});
+
+  @override
+  State<AddPricePage> createState() => _AddPricePageState();
+}
+
+class _AddPricePageState extends State<AddPricePage> {
+  final _formKey = GlobalKey<FormState>();
+  DateTime _checkedAt = DateTime.now();
+  Inventory? _inventory;
+  List<Inventory> _inventories = [];
+
+  double _count = 1;
+  double _volume = 1;
+  double _price = 0;
+  String _shop = '';
+
+  final AddPriceInfo _usecase = AddPriceInfo(PriceRepositoryImpl());
+
+  @override
+  void initState() {
+    super.initState();
+    final repo = InventoryRepositoryImpl();
+    // fetch all inventories once
+    FetchAllInventory(repo)().then((list) {
+      setState(() {
+        _inventories = list;
+        if (list.isNotEmpty) _inventory = list.first;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  double get _totalVolume => _count * _volume;
+  double get _unitPrice => _totalVolume == 0 ? 0 : _price / _totalVolume;
+
+  Future<void> _save() async {
+    if (_inventory == null) return;
+    final info = PriceInfo(
+      id: '',
+      inventoryId: _inventory!.id,
+      checkedAt: _checkedAt,
+      category: _inventory!.category,
+      itemType: _inventory!.itemType,
+      itemName: _inventory!.itemName,
+      count: _count,
+      unit: _inventory!.unit,
+      volume: _volume,
+      totalVolume: _totalVolume,
+      price: _price,
+      shop: _shop,
+      unitPrice: _unitPrice,
+    );
+    await _usecase(info);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('値段管理追加')),
+      body: _inventories.isEmpty
+          ? const Center(child: CircularProgressIndicator())
+          : Padding(
+              padding: const EdgeInsets.all(16),
+              child: Form(
+                key: _formKey,
+                child: ListView(
+                  children: [
+                    DropdownButtonFormField<Inventory>(
+                      decoration: const InputDecoration(labelText: '商品'),
+                      value: _inventory,
+                      items: _inventories
+                          .map((e) => DropdownMenuItem(
+                                value: e,
+                                child: Text('${e.itemType} / ${e.itemName}'),
+                              ))
+                          .toList(),
+                      onChanged: (v) => setState(() => _inventory = v),
+                    ),
+                    const SizedBox(height: 12),
+                    ListTile(
+                      title: Text('確認日: ${_checkedAt.year}/${_checkedAt.month}/${_checkedAt.day}'),
+                      trailing: const Icon(Icons.calendar_today),
+                      onTap: () async {
+                        final picked = await showDatePicker(
+                          context: context,
+                          firstDate: DateTime(2000),
+                          lastDate: DateTime(2100),
+                          initialDate: _checkedAt,
+                        );
+                        if (picked != null) setState(() => _checkedAt = picked);
+                      },
+                    ),
+                    const SizedBox(height: 12),
+                    TextFormField(
+                      decoration: const InputDecoration(labelText: '数'),
+                      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                      initialValue: '1',
+                      onChanged: (v) => setState(() => _count = double.tryParse(v) ?? 1),
+                    ),
+                    const SizedBox(height: 12),
+                    TextFormField(
+                      decoration: const InputDecoration(labelText: '容量'),
+                      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                      initialValue: '1',
+                      onChanged: (v) => setState(() => _volume = double.tryParse(v) ?? 1),
+                    ),
+                    const SizedBox(height: 12),
+                    TextFormField(
+                      decoration: const InputDecoration(labelText: '値段'),
+                      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                      onChanged: (v) => setState(() => _price = double.tryParse(v) ?? 0),
+                    ),
+                    const SizedBox(height: 12),
+                    TextFormField(
+                      decoration: const InputDecoration(labelText: '購入元'),
+                      onChanged: (v) => _shop = v,
+                    ),
+                    const SizedBox(height: 12),
+                    Text('合計容量: ${_totalVolume.toStringAsFixed(2)}'),
+                    Text('単価: ${_unitPrice.toStringAsFixed(2)}'),
+                    const SizedBox(height: 24),
+                    ElevatedButton(
+                      onPressed: () async {
+                        if (_formKey.currentState!.validate()) {
+                          try {
+                            await _save();
+                            if (!mounted) return;
+                            await ScaffoldMessenger.of(context)
+                                .showSnackBar(const SnackBar(content: Text('保存しました')))
+                                .closed;
+                            if (mounted) Navigator.pop(context);
+                          } catch (_) {
+                            if (mounted) {
+                              ScaffoldMessenger.of(context)
+                                  .showSnackBar(const SnackBar(content: Text('保存に失敗しました')));
+                            }
+                          }
+                        }
+                      },
+                      child: const Text('保存'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+    );
+  }
+}

--- a/lib/data/repositories/price_repository_impl.dart
+++ b/lib/data/repositories/price_repository_impl.dart
@@ -1,0 +1,75 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../../domain/entities/price_info.dart';
+import '../../domain/repositories/price_repository.dart';
+
+class PriceRepositoryImpl implements PriceRepository {
+  final FirebaseFirestore _firestore;
+  PriceRepositoryImpl({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  @override
+  Future<String> addPriceInfo(PriceInfo info) async {
+    final doc = await _firestore.collection('priceInfos').add({
+      'inventoryId': info.inventoryId,
+      'checkedAt': Timestamp.fromDate(info.checkedAt),
+      'category': info.category,
+      'itemType': info.itemType,
+      'itemName': info.itemName,
+      'count': info.count,
+      'unit': info.unit,
+      'volume': info.volume,
+      'totalVolume': info.totalVolume,
+      'price': info.price,
+      'shop': info.shop,
+      'unitPrice': info.unitPrice,
+      'createdAt': Timestamp.now(),
+    });
+    return doc.id;
+  }
+
+  @override
+  Stream<List<PriceInfo>> watchByCategory(String category) {
+    return _firestore
+        .collection('priceInfos')
+        .where('category', isEqualTo: category)
+        .orderBy('checkedAt', descending: true)
+        .snapshots()
+        .map((snapshot) => snapshot.docs.map(_fromDoc).toList());
+  }
+
+  @override
+  Stream<List<PriceInfo>> watchByType(String category, String itemType) {
+    return _firestore
+        .collection('priceInfos')
+        .where('category', isEqualTo: category)
+        .where('itemType', isEqualTo: itemType)
+        .orderBy('checkedAt', descending: true)
+        .snapshots()
+        .map((snapshot) => snapshot.docs.map(_fromDoc).toList());
+  }
+
+  PriceInfo _fromDoc(QueryDocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data();
+    return PriceInfo(
+      id: doc.id,
+      inventoryId: data['inventoryId'] ?? '',
+      checkedAt: (data['checkedAt'] as Timestamp).toDate(),
+      category: data['category'] ?? '',
+      itemType: data['itemType'] ?? '',
+      itemName: data['itemName'] ?? '',
+      count: (data['count'] ?? 0).toDouble(),
+      unit: data['unit'] ?? '',
+      volume: (data['volume'] ?? 0).toDouble(),
+      totalVolume: (data['totalVolume'] ?? 0).toDouble(),
+      price: (data['price'] ?? 0).toDouble(),
+      shop: data['shop'] ?? '',
+      unitPrice: (data['unitPrice'] ?? 0).toDouble(),
+    );
+  }
+
+  @override
+  Future<void> deletePriceInfo(String id) async {
+    await _firestore.collection('priceInfos').doc(id).delete();
+  }
+}

--- a/lib/domain/entities/price_info.dart
+++ b/lib/domain/entities/price_info.dart
@@ -1,0 +1,31 @@
+class PriceInfo {
+  final String id;
+  final String inventoryId;
+  final DateTime checkedAt;
+  final String category;
+  final String itemType;
+  final String itemName;
+  final double count;
+  final String unit;
+  final double volume;
+  final double totalVolume;
+  final double price;
+  final String shop;
+  final double unitPrice;
+
+  PriceInfo({
+    required this.id,
+    required this.inventoryId,
+    required this.checkedAt,
+    required this.category,
+    required this.itemType,
+    required this.itemName,
+    required this.count,
+    required this.unit,
+    required this.volume,
+    required this.totalVolume,
+    required this.price,
+    required this.shop,
+    required this.unitPrice,
+  });
+}

--- a/lib/domain/repositories/price_repository.dart
+++ b/lib/domain/repositories/price_repository.dart
@@ -1,0 +1,8 @@
+import '../entities/price_info.dart';
+
+abstract class PriceRepository {
+  Future<String> addPriceInfo(PriceInfo info);
+  Stream<List<PriceInfo>> watchByCategory(String category);
+  Stream<List<PriceInfo>> watchByType(String category, String itemType);
+  Future<void> deletePriceInfo(String id);
+}

--- a/lib/domain/usecases/add_price_info.dart
+++ b/lib/domain/usecases/add_price_info.dart
@@ -1,0 +1,11 @@
+import '../entities/price_info.dart';
+import '../repositories/price_repository.dart';
+
+class AddPriceInfo {
+  final PriceRepository repository;
+  AddPriceInfo(this.repository);
+
+  Future<void> call(PriceInfo info) async {
+    await repository.addPriceInfo(info);
+  }
+}

--- a/lib/domain/usecases/delete_price_info.dart
+++ b/lib/domain/usecases/delete_price_info.dart
@@ -1,0 +1,10 @@
+import '../repositories/price_repository.dart';
+
+class DeletePriceInfo {
+  final PriceRepository repository;
+  DeletePriceInfo(this.repository);
+
+  Future<void> call(String id) async {
+    await repository.deletePriceInfo(id);
+  }
+}

--- a/lib/domain/usecases/watch_price_by_category.dart
+++ b/lib/domain/usecases/watch_price_by_category.dart
@@ -1,0 +1,11 @@
+import '../entities/price_info.dart';
+import '../repositories/price_repository.dart';
+
+class WatchPriceByCategory {
+  final PriceRepository repository;
+  WatchPriceByCategory(this.repository);
+
+  Stream<List<PriceInfo>> call(String category) {
+    return repository.watchByCategory(category);
+  }
+}

--- a/lib/domain/usecases/watch_price_by_type.dart
+++ b/lib/domain/usecases/watch_price_by_type.dart
@@ -1,0 +1,11 @@
+import '../entities/price_info.dart';
+import '../repositories/price_repository.dart';
+
+class WatchPriceByType {
+  final PriceRepository repository;
+  WatchPriceByType(this.repository);
+
+  Stream<List<PriceInfo>> call(String category, String type) {
+    return repository.watchByType(category, type);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'add_category_page.dart';
 import 'settings_page.dart';
 import 'inventory_detail_page.dart';
 import 'edit_inventory_page.dart';
+import 'price_list_page.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'firebase_options.dart'; // ← 自動生成された設定ファイル
@@ -150,6 +151,11 @@ class _HomePageState extends State<HomePage> {
                           AddInventoryPage(categories: _categories),
                     ),
                   );
+                } else if (value == 'price') {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const PriceListPage()),
+                  );
                 } else if (value == 'settings') {
                   Navigator.push(
                     context,
@@ -165,6 +171,9 @@ class _HomePageState extends State<HomePage> {
                 const PopupMenuItem(
                     value: 'add',
                     child: Text('商品を追加', style: TextStyle(fontSize: 18))),
+                const PopupMenuItem(
+                    value: 'price',
+                    child: Text('値段管理', style: TextStyle(fontSize: 18))),
                 const PopupMenuItem(
                     value: 'settings',
                     child: Text('設定', style: TextStyle(fontSize: 18))),

--- a/lib/price_history_page.dart
+++ b/lib/price_history_page.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+import 'data/repositories/price_repository_impl.dart';
+import 'domain/entities/price_info.dart';
+import 'domain/usecases/delete_price_info.dart';
+import 'domain/usecases/watch_price_by_type.dart';
+
+class PriceHistoryPage extends StatelessWidget {
+  final String category;
+  final String itemType;
+  const PriceHistoryPage({super.key, required this.category, required this.itemType});
+
+  @override
+  Widget build(BuildContext context) {
+    final watch = WatchPriceByType(PriceRepositoryImpl());
+    final deleter = DeletePriceInfo(PriceRepositoryImpl());
+    return Scaffold(
+      appBar: AppBar(title: Text(itemType)),
+      body: StreamBuilder<List<PriceInfo>>(
+        stream: watch(category, itemType),
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final list = snapshot.data!;
+          return ListView(
+            children: [
+              for (final p in list)
+                ListTile(
+                  title: Text(p.itemName),
+                  subtitle: Text(
+                      '${_formatDate(p.checkedAt)} 数:${p.count} ${p.unit} 容量:${p.volume} 合計:${p.totalVolume} 値段:${p.price} 購入元:${p.shop} 単価:${p.unitPrice.toStringAsFixed(2)}'),
+                  onLongPress: () async {
+                    final res = await showModalBottomSheet<String>(
+                      context: context,
+                      builder: (_) => SafeArea(
+                        child: ListTile(
+                          leading: const Icon(Icons.delete),
+                          title: const Text('削除'),
+                          onTap: () => Navigator.pop(context, 'delete'),
+                        ),
+                      ),
+                    );
+                    if (res == 'delete') {
+                      await deleter(p.id);
+                    }
+                  },
+                )
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  String _formatDate(DateTime d) {
+    return '${d.year}/${d.month}/${d.day}';
+  }
+}

--- a/lib/price_list_page.dart
+++ b/lib/price_list_page.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import 'add_price_page.dart';
+import 'data/repositories/price_repository_impl.dart';
+import 'domain/entities/category.dart';
+import 'domain/entities/price_info.dart';
+import 'domain/usecases/watch_price_by_category.dart';
+import 'price_history_page.dart';
+
+class PriceListPage extends StatefulWidget {
+  const PriceListPage({super.key});
+
+  @override
+  State<PriceListPage> createState() => _PriceListPageState();
+}
+
+class _PriceListPageState extends State<PriceListPage> {
+  List<Category> _categories = [];
+  bool _loaded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    FirebaseFirestore.instance
+        .collection('categories')
+        .orderBy('createdAt')
+        .snapshots()
+        .listen((snapshot) {
+      setState(() {
+        _categories = snapshot.docs.map((d) {
+          final data = d.data();
+          return Category(
+            id: data['id'] ?? 0,
+            name: data['name'] ?? '',
+            createdAt: (data['createdAt'] as Timestamp).toDate(),
+          );
+        }).toList();
+        _loaded = true;
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_loaded) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('値段管理')),
+        body: const Center(child: CircularProgressIndicator()),
+      );
+    }
+    return DefaultTabController(
+      length: _categories.length,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('値段管理'),
+          bottom: TabBar(
+            isScrollable: true,
+            tabs: [for (final c in _categories) Tab(text: c.name)],
+          ),
+        ),
+        body: TabBarView(
+          children: [
+            for (final c in _categories) PriceCategoryList(category: c.name)
+          ],
+        ),
+        floatingActionButton: FloatingActionButton(
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const AddPricePage()),
+            );
+          },
+          child: const Icon(Icons.add),
+        ),
+      ),
+    );
+  }
+}
+
+class PriceCategoryList extends StatelessWidget {
+  final String category;
+  const PriceCategoryList({super.key, required this.category});
+
+  @override
+  Widget build(BuildContext context) {
+    final watch = WatchPriceByCategory(PriceRepositoryImpl());
+    return StreamBuilder<List<PriceInfo>>(
+      stream: watch(category),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final list = snapshot.data!;
+        final Map<String, PriceInfo> map = {};
+        for (final p in list) {
+          final current = map[p.itemType];
+          if (current == null || p.unitPrice < current.unitPrice) {
+            map[p.itemType] = p;
+          }
+        }
+        final items = map.values.toList()
+          ..sort((a, b) => a.itemType.compareTo(b.itemType));
+        return ListView(
+          children: [
+            for (final p in items)
+              ListTile(
+                title: Text(p.itemName),
+                subtitle: Text(
+                    '数:${p.count} ${p.unit} 容量:${p.volume} 合計:${p.totalVolume} 値段:${p.price} 購入元:${p.shop} 単価:${p.unitPrice.toStringAsFixed(2)}'),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => PriceHistoryPage(
+                        category: category,
+                        itemType: p.itemType,
+                      ),
+                    ),
+                  );
+                },
+              )
+          ],
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add price management entity, repository, and usecases
- implement Firestore repository for price information
- build pages for adding price info and viewing price lists/history
- integrate price management menu item in main page
- reorder menu so price management comes after item addition

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850273e3018832eb6e2a7358103eca8