### PR TITLE
Fix price list loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ W/Firestore: Listen for Query(target=Query(inventory where category==<value> ord
 `firebase deploy --only firestore:indexes` を実行してデプロイすることで解消でき
 ます。
 
+同様に、値段管理機能で利用する `priceInfos` コレクションをカテゴリや商品種別で
+絞り込むクエリでもインデックスが必要です。これらの定義も `firestore.indexes.json`
+に含めているので、設定後は同じコマンドでデプロイしてください。
+
 ## 実行手順
 
 次のコマンドを順に実行してアプリを起動します。

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -8,6 +8,25 @@
         { "fieldPath": "createdAt", "order": "DESCENDING" },
         { "fieldPath": "__name__", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "priceInfos",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "category", "order": "ASCENDING" },
+        { "fieldPath": "checkedAt", "order": "DESCENDING" },
+        { "fieldPath": "__name__", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "priceInfos",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "category", "order": "ASCENDING" },
+        { "fieldPath": "itemType", "order": "ASCENDING" },
+        { "fieldPath": "checkedAt", "order": "DESCENDING" },
+        { "fieldPath": "__name__", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/lib/price_history_page.dart
+++ b/lib/price_history_page.dart
@@ -19,6 +19,10 @@ class PriceHistoryPage extends StatelessWidget {
       body: StreamBuilder<List<PriceInfo>>(
         stream: watch(category, itemType),
         builder: (context, snapshot) {
+          if (snapshot.hasError) {
+            final err = snapshot.error?.toString() ?? '不明なエラー';
+            return Center(child: Text('読み込みエラー: $err'));
+          }
           if (!snapshot.hasData) {
             return const Center(child: CircularProgressIndicator());
           }

--- a/lib/price_list_page.dart
+++ b/lib/price_list_page.dart
@@ -39,6 +39,12 @@ class _PriceListPageState extends State<PriceListPage> {
         }).toList();
         _loaded = true;
       });
+    }, onError: (_) {
+      if (mounted) {
+        setState(() {
+          _loaded = true;
+        });
+      }
     });
   }
 
@@ -89,6 +95,10 @@ class PriceCategoryList extends StatelessWidget {
     return StreamBuilder<List<PriceInfo>>(
       stream: watch(category),
       builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          final err = snapshot.error?.toString() ?? '不明なエラー';
+          return Center(child: Text('読み込みエラー: $err'));
+        }
         if (!snapshot.hasData) {
           return const Center(child: CircularProgressIndicator());
         }


### PR DESCRIPTION
## Summary
- add Firestore indexes for priceInfos queries
- handle stream errors on price list and history pages
- document new indexes

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68502a4b6394832eb9d7e5bb6753d3c8