### PR TITLE
Update price list columns

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -49,5 +49,7 @@
   "unitPrice": "Unit price: {value}",
   "checkedDate": "Checked: {date}",
   "categorySettings": "Category Settings",
-  "priceSummary": "Count:{count} {unit} Volume:{volume} Total:{total} Price:{price} Shop:{shop} Unit price:{unitPrice}"
+  "priceSummary": "Count:{count} {unit} Volume:{volume} Total:{total} Price:{price} Shop:{shop} Unit price:{unitPrice}",
+  "totalVolumeLabel": "Total",
+  "unitPriceLabel": "Unit price"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -49,5 +49,7 @@
   "unitPrice": "単価: {value}",
   "checkedDate": "確認日: {date}",
   "categorySettings": "カテゴリ設定",
-  "priceSummary": "数:{count} {unit} 容量:{volume} 合計:{total} 値段:{price} 購入元:{shop} 単価:{unitPrice}"
+  "priceSummary": "数:{count} {unit} 容量:{volume} 合計:{total} 値段:{price} 購入元:{shop} 単価:{unitPrice}",
+  "totalVolumeLabel": "合計",
+  "unitPriceLabel": "単価"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -73,6 +73,8 @@ class AppLocalizations {
   String get shop => _get('shop');
   String totalVolume(String v) => (_strings['totalVolume'] ?? 'totalVolume {value}').replaceFirst('{value}', v);
   String unitPrice(String v) => (_strings['unitPrice'] ?? 'unitPrice {value}').replaceFirst('{value}', v);
+  String get totalVolumeLabel => _get('totalVolumeLabel');
+  String get unitPriceLabel => _get('unitPriceLabel');
   String checkedDate(String d) => (_strings['checkedDate'] ?? 'checked {date}').replaceFirst('{date}', d);
   String priceSummary({required String count, required String unitStr, required String volume, required String total, required String price, required String shop, required String unitPrice}) {
     var template = _strings['priceSummary'] ?? '';

--- a/lib/price_list_page.dart
+++ b/lib/price_list_page.dart
@@ -112,34 +112,47 @@ class PriceCategoryList extends StatelessWidget {
         }
         final items = map.values.toList()
           ..sort((a, b) => a.itemType.compareTo(b.itemType));
-        return ListView(
-          children: [
-            for (final p in items)
-              ListTile(
-                title: Text(p.itemName),
-                subtitle: Text(
-                    AppLocalizations.of(context).priceSummary(
-                      count: p.count.toString(),
-                      unitStr: p.unit,
-                      volume: p.volume.toString(),
-                      total: p.totalVolume.toString(),
-                      price: p.price.toString(),
-                      shop: p.shop,
-                      unitPrice: p.unitPrice.toStringAsFixed(2),
-                    )),
-                onTap: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => PriceHistoryPage(
-                        category: category,
-                        itemType: p.itemType,
-                      ),
-                    ),
-                  );
-                },
-              )
-          ],
+        return SingleChildScrollView(
+          scrollDirection: Axis.vertical,
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: DataTable(
+              columns: [
+                DataColumn(label: Text(AppLocalizations.of(context).itemName)),
+                DataColumn(label: Text(AppLocalizations.of(context).count)),
+                DataColumn(label: Text(AppLocalizations.of(context).volume)),
+                DataColumn(label: Text(AppLocalizations.of(context).totalVolumeLabel)),
+                DataColumn(label: Text(AppLocalizations.of(context).price)),
+                DataColumn(label: Text(AppLocalizations.of(context).shop)),
+                DataColumn(label: Text(AppLocalizations.of(context).unitPriceLabel)),
+              ],
+              rows: [
+                for (final p in items)
+                  DataRow(
+                    cells: [
+                      DataCell(Text(p.itemName)),
+                      DataCell(Text(p.count.toString())),
+                      DataCell(Text(p.volume.toString())),
+                      DataCell(Text(p.totalVolume.toString())),
+                      DataCell(Text(p.price.toString())),
+                      DataCell(Text(p.shop)),
+                      DataCell(Text(p.unitPrice.toStringAsFixed(2))),
+                    ],
+                    onSelectChanged: (_) {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => PriceHistoryPage(
+                            category: category,
+                            itemType: p.itemType,
+                          ),
+                        ),
+                      );
+                    },
+                  )
+              ],
+            ),
+          ),
         );
       },
     );


### PR DESCRIPTION
## Summary
- display price management list as a scrollable table
- adjust columns to show count, volume, total, price, shop, and unit price for each item

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685154522938832ebec47da803c37ffe