### PR TITLE
Implement buy list and notifications

### DIFF
--- a/lib/buy_list_page.dart
+++ b/lib/buy_list_page.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+import 'data/repositories/inventory_repository_impl.dart';
+import 'domain/entities/inventory.dart';
+import 'domain/usecases/watch_low_inventory.dart';
+import 'l10n/app_localizations.dart';
+
+class BuyListPage extends StatelessWidget {
+  final double threshold;
+  const BuyListPage({super.key, this.threshold = 0});
+
+  @override
+  Widget build(BuildContext context) {
+    final watch = WatchLowInventory(InventoryRepositoryImpl());
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(AppLocalizations.of(context).buyListTitle),
+      ),
+      body: StreamBuilder<List<Inventory>>(
+        stream: watch(threshold),
+        builder: (context, snapshot) {
+          if (snapshot.hasError) {
+            final err = snapshot.error?.toString() ?? 'unknown';
+            return Center(child: Text(AppLocalizations.of(context).loadError(err)));
+          }
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final list = snapshot.data!;
+          if (list.isEmpty) {
+            return Center(child: Text(AppLocalizations.of(context).noBuyItems));
+          }
+          return ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              for (final inv in list)
+                ListTile(
+                  title: Text('${inv.itemType} / ${inv.itemName}'),
+                  subtitle: Text('${inv.quantity.toStringAsFixed(1)}${inv.unit}'),
+                ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/data/repositories/inventory_repository_impl.dart
+++ b/lib/data/repositories/inventory_repository_impl.dart
@@ -155,4 +155,26 @@ class InventoryRepositoryImpl implements InventoryRepository {
   Future<void> deleteInventory(String id) async {
     await _firestore.collection('inventory').doc(id).delete();
   }
+
+  @override
+  Stream<List<Inventory>> watchNeedsBuy(double threshold) {
+    return _firestore
+        .collection('inventory')
+        .where('quantity', isLessThanOrEqualTo: threshold)
+        .orderBy('quantity')
+        .snapshots()
+        .map((snapshot) => snapshot.docs.map((doc) {
+              final data = doc.data();
+              return Inventory(
+                id: doc.id,
+                itemName: data['itemName'] ?? '',
+                category: data['category'] ?? '',
+                itemType: data['itemType'] ?? '',
+                quantity: (data['quantity'] ?? 0).toDouble(),
+                unit: data['unit'] ?? '',
+                note: data['note'] ?? '',
+                createdAt: (data['createdAt'] as Timestamp).toDate(),
+              );
+            }).toList());
+  }
 }

--- a/lib/domain/repositories/inventory_repository.dart
+++ b/lib/domain/repositories/inventory_repository.dart
@@ -22,4 +22,7 @@ abstract class InventoryRepository {
 
   /// 在庫を削除する
   Future<void> deleteInventory(String id);
+
+  /// 残量が一定以下の在庫を監視する
+  Stream<List<Inventory>> watchNeedsBuy(double threshold);
 }

--- a/lib/domain/usecases/watch_low_inventory.dart
+++ b/lib/domain/usecases/watch_low_inventory.dart
@@ -1,0 +1,12 @@
+import '../entities/inventory.dart';
+import '../repositories/inventory_repository.dart';
+
+/// 残量が一定以下の在庫を監視するユースケース
+class WatchLowInventory {
+  final InventoryRepository repository;
+  WatchLowInventory(this.repository);
+
+  Stream<List<Inventory>> call(double threshold) {
+    return repository.watchNeedsBuy(threshold);
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -51,5 +51,10 @@
   "categorySettings": "Category Settings",
   "priceSummary": "Count:{count} {unit} Volume:{volume} Total:{total} Price:{price} Shop:{shop} Unit price:{unitPrice}",
   "totalVolumeLabel": "Total",
-  "unitPriceLabel": "Unit price"
+  "unitPriceLabel": "Unit price",
+  "buyList": "Buy List",
+  "buyListTitle": "Items to Buy",
+  "noBuyItems": "No items to buy",
+  "buyListNotificationTitle": "Shopping Reminder",
+  "buyListNotificationBody": "Check items to buy"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -51,5 +51,10 @@
   "categorySettings": "カテゴリ設定",
   "priceSummary": "数:{count} {unit} 容量:{volume} 合計:{total} 値段:{price} 購入元:{shop} 単価:{unitPrice}",
   "totalVolumeLabel": "合計",
-  "unitPriceLabel": "単価"
+  "unitPriceLabel": "単価",
+  "buyList": "買い物リスト",
+  "buyListTitle": "買うべきリスト",
+  "noBuyItems": "買うものはありません",
+  "buyListNotificationTitle": "買い物リマインダー",
+  "buyListNotificationBody": "買うべき在庫を確認してください"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -88,6 +88,11 @@ class AppLocalizations {
         .replaceFirst('{unitPrice}', unitPrice);
   }
   String get categorySettings => _get('categorySettings');
+  String get buyList => _get('buyList');
+  String get buyListTitle => _get('buyListTitle');
+  String get noBuyItems => _get('noBuyItems');
+  String get buyListNotificationTitle => _get('buyListNotificationTitle');
+  String get buyListNotificationBody => _get('buyListNotificationBody');
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'settings_page.dart';
 import 'inventory_detail_page.dart';
 import 'edit_inventory_page.dart';
 import 'price_list_page.dart';
+import 'buy_list_page.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'firebase_options.dart'; // ← 自動生成された設定ファイル
@@ -20,6 +21,7 @@ import 'domain/usecases/watch_inventories.dart';
 import 'domain/usecases/update_quantity.dart';
 import 'domain/usecases/delete_inventory.dart';
 import 'domain/usecases/stocktake.dart';
+import 'notification_service.dart';
 
 // アプリのエントリーポイント。Firebase を初期化してから起動する。
 
@@ -28,6 +30,16 @@ void main() async {
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   ); // Firebase の初期設定
+  final locale = WidgetsBinding.instance.platformDispatcher.locale;
+  final loc = AppLocalizations(locale);
+  await loc.load();
+  final notification = NotificationService();
+  await notification.init();
+  await notification.scheduleWeekly(
+    id: 0,
+    title: loc.buyListNotificationTitle,
+    body: loc.buyListNotificationBody,
+  );
   runApp(const MyApp()); // アプリのスタート
 }
 
@@ -165,6 +177,11 @@ class _HomePageState extends State<HomePage> {
                     context,
                     MaterialPageRoute(builder: (_) => const PriceListPage()),
                   );
+                } else if (value == 'buylist') {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const BuyListPage()),
+                  );
                 } else if (value == 'settings') {
                   Navigator.push(
                     context,
@@ -184,6 +201,10 @@ class _HomePageState extends State<HomePage> {
                 PopupMenuItem(
                     value: 'price',
                     child: Text(AppLocalizations.of(context).priceManagement,
+                        style: const TextStyle(fontSize: 18))),
+                PopupMenuItem(
+                    value: 'buylist',
+                    child: Text(AppLocalizations.of(context).buyList,
                         style: const TextStyle(fontSize: 18))),
                 PopupMenuItem(
                     value: 'settings',

--- a/lib/notification_service.dart
+++ b/lib/notification_service.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
+
+class NotificationService {
+  final FlutterLocalNotificationsPlugin _plugin = FlutterLocalNotificationsPlugin();
+
+  Future<void> init() async {
+    const android = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const ios = DarwinInitializationSettings();
+    const settings = InitializationSettings(android: android, iOS: ios);
+    await _plugin.initialize(settings);
+    tz.initializeTimeZones();
+  }
+
+  tz.TZDateTime _nextInstance(int weekday, int hour, int minute) {
+    final now = tz.TZDateTime.now(tz.local);
+    var scheduled = tz.TZDateTime(tz.local, now.year, now.month, now.day, hour, minute);
+    while (scheduled.weekday != weekday || scheduled.isBefore(now)) {
+      scheduled = scheduled.add(const Duration(days: 1));
+    }
+    return scheduled;
+  }
+
+  Future<void> scheduleWeekly({
+    required int id,
+    required String title,
+    required String body,
+    int weekday = DateTime.friday,
+    int hour = 18,
+    int minute = 0,
+  }) async {
+    await _plugin.zonedSchedule(
+      id,
+      title,
+      body,
+      _nextInstance(weekday, hour, minute),
+      const NotificationDetails(
+        android: AndroidNotificationDetails('buy_list', 'Buy List'),
+      ),
+      androidAllowWhileIdle: true,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
+      matchDateTimeComponents: DateTimeComponents.dayOfWeekAndTime,
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   firebase_core: ^2.25.0
   cloud_firestore: ^4.14.0
+  flutter_local_notifications: ^17.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- query Firestore for low inventory items
- display items to buy with new BuyListPage
- add weekly notification scheduling
- expose strings for new UI and notifications

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68515b379c08832e99cdbb7e629913c5