### PR TITLE
Fix l10n generation

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,8 @@ dev_dependencies:
 # The following section is specific to Flutter packages.
 flutter:
 
+  generate: true
+
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.


### PR DESCRIPTION
## Summary
- enable Flutter l10n code generation

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851678f7b9c832ea573e76c4f23b22a