### PR TITLE
Fix build errors for home screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,8 @@ import 'inventory_detail_page.dart';
 import 'edit_inventory_page.dart';
 import 'price_list_page.dart';
 import 'buy_list_page.dart';
+import 'domain/usecases/watch_low_inventory.dart';
+import 'widgets/inventory_card.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -90,7 +92,7 @@ class _MyAppState extends State<MyApp> {
         useMaterial3: true,
       ),
       // ホーム画面では買い物リストを表示する
-      home: HomePage(categories: initialCategories),
+      home: HomePage(categories: widget.initialCategories),
     );
   }
 }
@@ -175,6 +177,7 @@ class _HomePageState extends State<HomePage> {
       );
     }
 
+    // 残量が少ない在庫を監視するユースケース
     final watch = WatchLowInventory(InventoryRepositoryImpl());
     return Scaffold(
       appBar: AppBar(
@@ -208,9 +211,12 @@ class _HomePageState extends State<HomePage> {
                 Navigator.push(
                   context,
                   MaterialPageRoute(
+                      // 設定メニューを開いたときに表示する画面
                       builder: (_) => SettingsPage(
                             categories: _categories,
                             onChanged: _updateCategories,
+                            onLocaleChanged: (l) =>
+                                context.findAncestorStateOfType<_MyAppState>()?._updateLocale(l),
                           )),
                 );
               }
@@ -525,6 +531,7 @@ class InventoryList extends StatelessWidget {
                   );
                 }
               },
+              // 各在庫を表示するカードウィジェット
               child: InventoryCard(inventory: inv),
             );
           }).toList(),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -11,13 +11,16 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:oouchi_stock/main.dart';
 import 'firebase_test_utils.dart';
 import 'package:oouchi_stock/add_category_page.dart';
+import 'package:oouchi_stock/domain/entities/category.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('アプリが起動する', (WidgetTester tester) async {
-    await tester.pumpWidget(
-        const MyApp(initialCategories: ['日用品']));
+    final categories = [
+      Category(id: 1, name: '日用品', createdAt: DateTime.now())
+    ];
+    await tester.pumpWidget(MyApp(initialCategories: categories));
     expect(find.text('おうちストック'), findsOneWidget);
   });
 


### PR DESCRIPTION
## Summary
- ホーム画面の設定で初期カテゴリを参照する際に `widget` を付け忘れていたため修正
- 設定画面遷移時に言語変更ハンドラを渡すように変更
- WatchLowInventory と InventoryCard の不足インポートを追加
- `InventoryList` 内のカード表示にコメントを追加
- widget_test.dart を Category オブジェクトを使う形に修正

## Testing
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852980a5ec0832e9ed30f4321d4db7f