### PR TITLE
コンパイルエラー解消とコメント追加

### DIFF
--- a/lib/domain/entities/buy_list_condition_settings.dart
+++ b/lib/domain/entities/buy_list_condition_settings.dart
@@ -1,3 +1,5 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
 enum BuyListConditionType { threshold, days, or }
 
 class BuyListConditionSettings {
@@ -10,8 +12,6 @@ class BuyListConditionSettings {
     required this.days,
   });
 }
-
-import 'package:shared_preferences/shared_preferences.dart';
 
 /// 設定を読み込む
 Future<BuyListConditionSettings> loadBuyListConditionSettings() async {

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -9,6 +9,7 @@ import 'inventory_page.dart';
 import 'settings_page.dart';
 import 'inventory_detail_page.dart';
 import 'widgets/inventory_card.dart';
+import 'main.dart';
 import 'data/repositories/inventory_repository_impl.dart';
 import 'domain/entities/category.dart';
 import 'domain/entities/inventory.dart';
@@ -44,6 +45,7 @@ class _HomePageState extends State<HomePage> {
   }
 
   Future<void> _loadCondition() async {
+    // 設定画面から戻った際にも呼ばれ、買い物リスト条件を再読込する
     final s = await loadBuyListConditionSettings();
     setState(() => _conditionSettings = s);
   }
@@ -153,6 +155,7 @@ class _HomePageState extends State<HomePage> {
                             categories: _categories,
                             onChanged: _updateCategories,
                             onLocaleChanged: (l) =>
+                                // ルートの MyAppState に通知してアプリ全体の言語を更新
                                 context.findAncestorStateOfType<MyAppState>()?._updateLocale(l),
                             onConditionChanged: _loadCondition,
                           )),

--- a/lib/inventory_page.dart
+++ b/lib/inventory_page.dart
@@ -10,6 +10,7 @@ import 'settings_page.dart';
 import 'inventory_detail_page.dart';
 import 'edit_inventory_page.dart';
 import 'widgets/inventory_card.dart';
+import 'main.dart';
 import 'data/repositories/inventory_repository_impl.dart';
 import 'domain/entities/category.dart';
 import 'domain/entities/inventory.dart';
@@ -152,7 +153,10 @@ class _InventoryPageState extends State<InventoryPage> {
                                 categories: _categories,
                                 onChanged: _updateCategories,
                                 onLocaleChanged: (l) =>
+                                    // ルートの MyAppState に通知してアプリ全体の言語を更新
                                     context.findAncestorStateOfType<MyAppState>()?._updateLocale(l),
+                                // 在庫画面からは買い物リスト条件を利用しないため空実装
+                                onConditionChanged: () {},
                               )),
                     );
                   }

--- a/lib/widgets/inventory_card.dart
+++ b/lib/widgets/inventory_card.dart
@@ -137,6 +137,7 @@ class InventoryCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // ホーム画面や在庫一覧で表示される1商品のカードUI
     return FutureBuilder<DateTime>(
       future: _loadPrediction(),
       builder: (context, snapshot) {
@@ -188,7 +189,8 @@ class InventoryCard extends StatelessWidget {
               ],
             ),
           ),
-        );
+        ),
+      );
       },
     );
   }


### PR DESCRIPTION
## 概要
Flutter 実行時に発生していたコンパイルエラーを修正しました。併せてコードの理解を助ける日本語コメントを追加しました。

## 主な修正点
- `InventoryCard` の括弧抜けを修正
- `BuyListConditionSettings` の import 位置を修正
- `HomePage` / `InventoryPage` で `MyAppState` を参照するための import 追加
- `InventoryPage` の `SettingsPage` 呼び出しに必須パラメータを補完
- 各所に画面遷移や処理内容を説明する日本語コメントを追加

## テスト
- `flutter test` (実行不可のためエラー確認)


------
https://chatgpt.com/codex/tasks/task_e_6852a2380348832e8bc1a8aea4a727ab