### PR TITLE
言語設定更新メソッドを公開

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -156,7 +156,7 @@ class _HomePageState extends State<HomePage> {
                             onChanged: _updateCategories,
                             onLocaleChanged: (l) =>
                                 // ルートの MyAppState に通知してアプリ全体の言語を更新
-                                context.findAncestorStateOfType<MyAppState>()?._updateLocale(l),
+                                context.findAncestorStateOfType<MyAppState>()?.updateLocale(l),
                             onConditionChanged: _loadCondition,
                           )),
                 );

--- a/lib/inventory_page.dart
+++ b/lib/inventory_page.dart
@@ -154,7 +154,7 @@ class _InventoryPageState extends State<InventoryPage> {
                                 onChanged: _updateCategories,
                                 onLocaleChanged: (l) =>
                                     // ルートの MyAppState に通知してアプリ全体の言語を更新
-                                    context.findAncestorStateOfType<MyAppState>()?._updateLocale(l),
+                                    context.findAncestorStateOfType<MyAppState>()?.updateLocale(l),
                                 // 在庫画面からは買い物リスト条件を利用しないため空実装
                                 onConditionChanged: () {},
                               )),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -51,7 +51,10 @@ class MyAppState extends State<MyApp> {
     if (code != null) setState(() => _locale = Locale(code));
   }
 
-  Future<void> _updateLocale(Locale locale) async {
+  /// アプリ全体の言語設定を更新する
+  ///
+  /// [locale] 新しく設定するロケール
+  Future<void> updateLocale(Locale locale) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString('locale', locale.languageCode);
     setState(() => _locale = locale);


### PR DESCRIPTION
## 概要
`_updateLocale` が他ファイルから参照できずビルドに失敗していたため、メソッド名を `updateLocale` として公開化しました。これに伴い、`home_page.dart` と `inventory_page.dart` 内の呼び出し箇所を修正しました。

## テスト
- `flutter test` を実行しようとしましたが、環境に Flutter が存在しないため実行できませんでした。

------
https://chatgpt.com/codex/tasks/task_e_6852a365a198832eaff4c3985c630845