### PR TITLE
Java 17 対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
 
+## 開発環境の前提
+
+Android ビルドを行う場合は JDK 17 が必要です。`JAVA_HOME` が JDK 17 を指してい
+ることを確認してください。
+
 ## Firebase の設定
 
 [FlutterFire CLI](https://firebase.flutter.dev/docs/cli) を使って Firebase プロジェクトを構成します。初回セットアップや設定を変更したい場合は次のコマンドを実行します。

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -15,15 +15,19 @@ android {
     ndkVersion = "27.0.12077973"
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        // Java 17 を利用する設定。Flutter 3.13 以降の推奨バージョンに合わせています
+        // この設定は Android ビルド時に使用され、ホーム画面や在庫画面など
+        // すべての画面をビルドする際に適用されます
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
         // flutter_local_notifications などの依存ライブラリが利用する
-        // Java 8+ API を有効化するため desugaring をオンにする
+        // Java 8 以降の API を下位 API レベルでも利用できるよう desugaring を有効化
         isCoreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11.toString()
+        // Kotlin コンパイルターゲットも JDK 17 に合わせる
+        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     defaultConfig {


### PR DESCRIPTION
## Summary
- Android ビルド設定を JDK 17 に変更
- README に JDK 17 が必要な旨を追記

## Testing
- `flutter test` *(失敗: `flutter` が見つからない)*

------
https://chatgpt.com/codex/tasks/task_e_685418c2e438832ea395c1b182dd7d78