### PR TITLE
Add common theme

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'notification_service.dart';
 import 'home_page.dart';
 import 'login_page.dart';
 import 'root_navigation_page.dart';
+import 'theme.dart';
 
 // アプリのエントリーポイント。初期化処理中はローディング画面を表示する。
 
@@ -87,10 +88,8 @@ class _AppLoaderState extends State<AppLoader> {
           GlobalCupertinoLocalizations.delegate,
         ],
         supportedLocales: AppLocalizations.supportedLocales,
-        theme: ThemeData(
-          colorScheme: ColorScheme.fromSeed(seedColor: Colors.teal),
-          useMaterial3: true,
-        ),
+        // 共通のテーマ設定を適用
+        theme: AppTheme.lightTheme,
         home: LoginPage(onLoggedIn: () async {
           await _setupNotification();
           setState(() => _loggedIn = true);
@@ -178,10 +177,8 @@ class MyAppState extends State<MyApp> {
       ],
       supportedLocales: AppLocalizations.supportedLocales,
       locale: _locale,
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.teal),
-        useMaterial3: true,
-      ),
+      // 共通のテーマ設定を適用
+      theme: AppTheme.lightTheme,
       // 画面下部のメニューで各機能へ移動できる RootNavigationPage を表示
       home: const RootNavigationPage(),
     );

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+/// アプリ共通のテーマを定義するクラス
+class AppTheme {
+  // アクションに使用するメインカラー
+  static const Color primaryColor = Color(0xFF4A90E2);
+  // 画面の背景色
+  static const Color scaffoldBackgroundColor = Color(0xFFF5F5F5);
+  // セール表示に利用する色
+  static const Color saleColor = Color(0xFFD0021B);
+  // 成功や推奨を示す色
+  static const Color successColor = Color(0xFF7ED321);
+  // メインテキストの色
+  static const Color textColor = Color(0xFF333333);
+  // 補助テキストの色
+  static const Color subTextColor = Color(0xFF888888);
+
+  /// ライトテーマの定義
+  static ThemeData get lightTheme {
+    final baseTextTheme = TextTheme(
+      titleLarge: GoogleFonts.notoSansJp(
+        fontSize: 20,
+        fontWeight: FontWeight.bold,
+        color: textColor,
+      ),
+      bodyLarge: GoogleFonts.notoSansJp(
+        fontSize: 16,
+        fontWeight: FontWeight.normal,
+        color: textColor,
+      ),
+      labelLarge: GoogleFonts.notoSansJp(
+        fontSize: 14,
+        fontWeight: FontWeight.w500,
+        color: textColor,
+      ),
+      bodySmall: GoogleFonts.notoSansJp(
+        fontSize: 12,
+        fontWeight: FontWeight.w400,
+        color: subTextColor,
+      ),
+    );
+
+    final colorScheme = ColorScheme(
+      brightness: Brightness.light,
+      primary: primaryColor,
+      onPrimary: Colors.white,
+      secondary: successColor,
+      onSecondary: Colors.white,
+      error: saleColor,
+      onError: Colors.white,
+      background: scaffoldBackgroundColor,
+      onBackground: textColor,
+      surface: Colors.white,
+      onSurface: textColor,
+    );
+
+    return ThemeData(
+      useMaterial3: true,
+      colorScheme: colorScheme,
+      scaffoldBackgroundColor: scaffoldBackgroundColor,
+      textTheme: baseTextTheme,
+      appBarTheme: AppBarTheme(
+        backgroundColor: primaryColor,
+        foregroundColor: Colors.white,
+        titleTextStyle:
+            baseTextTheme.titleLarge?.copyWith(color: Colors.white),
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: primaryColor,
+          foregroundColor: Colors.white,
+          textStyle: baseTextTheme.labelLarge,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8),
+          ),
+        ),
+      ),
+      outlinedButtonTheme: OutlinedButtonThemeData(
+        style: OutlinedButton.styleFrom(
+          foregroundColor: primaryColor,
+          textStyle: baseTextTheme.labelLarge,
+          side: const BorderSide(color: primaryColor),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8),
+          ),
+        ),
+      ),
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(
+          foregroundColor: primaryColor,
+          textStyle: baseTextTheme.labelLarge,
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   flutter_local_notifications: ^17.1.0
   shared_preferences: ^2.2.2
   connectivity_plus: ^6.0.3
+  google_fonts: ^4.0.3
 
 dev_dependencies:
   flutter_test:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -12,6 +12,7 @@ import 'package:oouchi_stock/main.dart';
 import 'firebase_test_utils.dart';
 import 'package:oouchi_stock/add_category_page.dart';
 import 'package:oouchi_stock/domain/entities/category.dart';
+import 'package:oouchi_stock/theme.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -30,5 +31,10 @@ void main() {
     await tester.tap(find.text('保存'));
     await tester.pump();
     expect(find.text('必須項目です'), findsOneWidget);
+  });
+
+  test('AppTheme のプライマリカラーが設定されている', () {
+    final theme = AppTheme.lightTheme;
+    expect(theme.colorScheme.primary, AppTheme.primaryColor);
   });
 }


### PR DESCRIPTION
## Summary
- add theme.dart with colors & typography
- use the theme from main.dart
- include google_fonts dependency
- update widget tests for new theme

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855406496c8832e9849d8b417b469c2