### PR TITLE
フォント設定の修正

### DIFF
--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -18,23 +18,25 @@ class AppTheme {
 
   /// ライトテーマの定義
   static ThemeData get lightTheme {
+    // アプリ全体で使用するテキストスタイルを定義
+    // 画面読み込み時に ThemeData として読み込まれます
     final baseTextTheme = TextTheme(
-      titleLarge: GoogleFonts.notoSansJp(
+      titleLarge: GoogleFonts.notoSansJP(
         fontSize: 20,
         fontWeight: FontWeight.bold,
         color: textColor,
       ),
-      bodyLarge: GoogleFonts.notoSansJp(
+      bodyLarge: GoogleFonts.notoSansJP(
         fontSize: 16,
         fontWeight: FontWeight.normal,
         color: textColor,
       ),
-      labelLarge: GoogleFonts.notoSansJp(
+      labelLarge: GoogleFonts.notoSansJP(
         fontSize: 14,
         fontWeight: FontWeight.w500,
         color: textColor,
       ),
-      bodySmall: GoogleFonts.notoSansJp(
+      bodySmall: GoogleFonts.notoSansJP(
         fontSize: 12,
         fontWeight: FontWeight.w400,
         color: subTextColor,


### PR DESCRIPTION
## 概要
GoogleFonts の関数名 `notoSansJp` が存在せずビルドエラーとなっていたため、`notoSansJP` へ修正しました。併せて、アプリ起動時に読み込まれるテキストスタイルであることを示す日本語コメントを追加しました。

## テスト結果
- `flutter test` (実行不可: `flutter` コマンドが存在しないため)

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685541fd4a94832eb860649d74005890