### PR TITLE
Fix dropdown value mismatch

### DIFF
--- a/lib/add_inventory_page.dart
+++ b/lib/add_inventory_page.dart
@@ -113,6 +113,9 @@ class _AddInventoryPageState extends State<AddInventoryPage> {
           final types = _typesMap[_category!.name];
           if (types != null && types.isNotEmpty) {
             _itemType = types.first;
+          } else {
+            // 品種が存在しない場合は "その他" を初期値とする
+            _itemType = 'その他';
           }
         }
       });
@@ -165,20 +168,31 @@ class _AddInventoryPageState extends State<AddInventoryPage> {
                     final types = _typesMap[value.name];
                     if (types != null && types.isNotEmpty) {
                       _itemType = types.first;
+                    } else {
+                      // 品種が存在しないカテゴリを選んだ場合は "その他" に変更
+                      _itemType = 'その他';
                     }
                   });
                 },
               ),
               const SizedBox(height: 12),
               // 品種選択
-              DropdownButtonFormField<String>(
-                decoration: InputDecoration(labelText: AppLocalizations.of(context)!.itemType),
-                value: _itemType,
-                items: (_typesMap[_category?.name] ?? ['その他'])
-                    .map((t) => DropdownMenuItem(value: t, child: Text(t)))
-                .toList(),
-                onChanged: (value) => setState(() => _itemType = value ?? ''),
-              ),
+              Builder(builder: (context) {
+                // 現在選択中のカテゴリに対応する品種リストを取得
+                final itemTypes = _typesMap[_category?.name] ?? ['その他'];
+                // ドロップダウンに存在しない値を選んでいる場合は先頭に合わせる
+                if (!itemTypes.contains(_itemType)) {
+                  _itemType = itemTypes.first;
+                }
+                return DropdownButtonFormField<String>(
+                  decoration: InputDecoration(labelText: AppLocalizations.of(context)!.itemType),
+                  value: _itemType,
+                  items: itemTypes
+                      .map((t) => DropdownMenuItem(value: t, child: Text(t)))
+                      .toList(),
+                  onChanged: (value) => setState(() => _itemType = value ?? ''),
+                );
+              }),
               const SizedBox(height: 12),
               Row(
                 children: [


### PR DESCRIPTION
## Summary
- 在庫追加画面の品種選択で存在しない値がセットされていると例外が発生する問題を解消
- カテゴリ変更や品種データ更新時に"その他"を初期値として設定
- ドロップダウン表示時にも値を検証し存在しない場合は先頭の値に修正

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68554b707490832e8ec1bdaf4582f3ee