### PR TITLE
Fix Android Window dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ samples, guidance on mobile development, and a full API reference.
 Android ビルドを行う場合は JDK 17 が必要です。`JAVA_HOME` が JDK 17 を指してい
 ることを確認してください。
 
+折りたたみ端末などの最新機種に対応するため、AndroidX Window ライブラリを利用しています。
+ビルド時にエラーが発生する場合は `androidx.window:window` が取得できているか確認してください。
+
 ## Firebase の設定
 
 [FlutterFire CLI](https://firebase.flutter.dev/docs/cli) を使って Firebase プロジェクトを構成します。初回セットアップや設定を変更したい場合は次のコマンドを実行します。

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -57,6 +57,10 @@ flutter {
 dependencies {
     // Ensure ProviderInstaller is available at runtime
     implementation("com.google.android.gms:play-services-base:18.4.0")
+    // 折りたたみ端末などのウィンドウ情報取得に必要なライブラリ
+    // FlutterView が WindowInfoTracker を利用する際に参照され、
+    // 画面が表示されるタイミングでロードされる
+    implementation("androidx.window:window:1.2.0")
     // Desugaring library required when using Java 8+ APIs on lower API levels
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
 }

--- a/android/app/src/main/kotlin/com/example/oouchi_stock/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/oouchi_stock/MainActivity.kt
@@ -7,15 +7,17 @@ import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.security.ProviderInstaller
 import io.flutter.embedding.android.FlutterActivity
 
+/// アプリ起動時に最初に表示される画面をホストする Activity
+/// 各 Flutter 画面 (ホーム、在庫一覧など) はここから生成される
+
 class MainActivity : FlutterActivity(), ProviderInstaller.ProviderInstallListener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // Ensure Google Play services' security provider is installed when
-        // Google Play services is available on the device. Some emulator
-        // images do not include Play services and calling
-        // ProviderInstaller without this check results in a
-        // SecurityException.
+        // アプリ起動直後に呼ばれ、ホーム画面などの Flutter 画面を表示する前に
+        // Google Play 開発者サービスのセキュリティプロバイダーを確認する
+        // 一部のエミュレーターには Play services が含まれていないため
+        // ProviderInstaller 呼び出し前にチェックしないと SecurityException が発生する
         val availability = GoogleApiAvailability.getInstance()
         val result = availability.isGooglePlayServicesAvailable(this)
         if (result == ConnectionResult.SUCCESS) {


### PR DESCRIPTION
## Summary
- add AndroidX Window dependency to prevent Sidecar callback errors
- document the dependency in README
- describe MainActivity responsibilities in Japanese

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68554b2aab94832e83ba5255458b1711