### PR TITLE
home_pageの不要なstrategy削除

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -14,7 +14,6 @@ import 'data/repositories/inventory_repository_impl.dart';
 import 'domain/entities/category.dart';
 import 'domain/entities/inventory.dart';
 import 'domain/entities/category_order.dart';
-import 'domain/services/buy_list_strategy.dart';
 import 'domain/services/purchase_prediction_strategy.dart';
 import 'domain/entities/buy_list_condition_settings.dart';
 
@@ -139,11 +138,10 @@ class _HomePageState extends State<HomePage> {
       );
     }
 
-    // 買い物予報を生成するストラテジーを作成
+    // 買い物予報条件が未読込の場合はローディングを表示
     if (_conditionSettings == null) {
       return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
-    final strategy = createStrategy(_conditionSettings!);
     final repo = InventoryRepositoryImpl();
     return Scaffold(
       appBar: AppBar(


### PR DESCRIPTION
## Summary
- `home_page.dart` で未使用となっていた `strategy` 変数の生成を削除
- 代わりに買い物予報条件が未読込の場合のコメントを追記
- 未使用となった `buy_list_strategy.dart` のインポートを削除

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68554caa1244832e99b10284f3801726