### PR TITLE
androidx.window を 1.1.0 に固定

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Android ビルドを行う場合は JDK 17 が必要です。`JAVA_HOME` が JDK
 ることを確認してください。
 
 折りたたみ端末などの最新機種に対応するため、AndroidX Window ライブラリを利用しています。
-ビルド時にエラーが発生する場合は `androidx.window:window` が取得できているか確認してください。
+Flutter エンジンと互換性のある `1.1.x` 系を使用しており、`android/app/build.gradle.kts` では `1.1.0` を指定しています。
+ビルド時にエラーが発生する場合は `androidx.window:window` が正しいバージョンで取得できているか確認してください。
 
 ## Firebase の設定
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -60,7 +60,9 @@ dependencies {
     // 折りたたみ端末などのウィンドウ情報取得に必要なライブラリ
     // FlutterView が WindowInfoTracker を利用する際に参照され、
     // 画面が表示されるタイミングでロードされる
-    implementation("androidx.window:window:1.2.0")
+    // Flutter エンジンが想定している Window ライブラリのバージョンに合わせる
+    // 画面が表示されるときに折りたたみ端末の情報を取得するために利用
+    implementation("androidx.window:window:1.1.0")
     // Desugaring library required when using Java 8+ APIs on lower API levels
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
 }


### PR DESCRIPTION
## Summary
- android/app/build.gradle.kts の `androidx.window:window` を 1.1.0 に変更
- README に使用バージョンを追記

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68554d8559ac832e9590a9d24e4e3bb5