### PR TITLE
クリーンアーキテクチャ整理

### DIFF
--- a/docs/architecture_proposals_ja.md
+++ b/docs/architecture_proposals_ja.md
@@ -8,6 +8,8 @@
 - 例として `InventoryCard` を `lib/widgets/inventory_card.dart` へ分離しました。
 - 同様に `main.dart` にあったホーム画面と在庫画面を
   `lib/home_page.dart` と `lib/inventory_page.dart` に切り出しています。
+- 論理処理は可能な限り UseCase として切り出します。例えば
+  `HomePage` にあった残り日数計算処理を `CalculateDaysLeft` ユースケースへ移動しました。
 
 ## 2. 状態管理の導入
 - UI とビジネスロジックを分離するため、Riverpod や BLoC などの状態管理ライブラリを利用します。

--- a/lib/domain/usecases/calculate_days_left.dart
+++ b/lib/domain/usecases/calculate_days_left.dart
@@ -1,0 +1,28 @@
+import '../entities/inventory.dart';
+import '../services/purchase_prediction_strategy.dart';
+import '../repositories/inventory_repository.dart';
+
+/// 在庫履歴から残り日数を計算するユースケース
+class CalculateDaysLeft {
+  final InventoryRepository repository;
+  final PurchasePredictionStrategy strategy;
+
+  CalculateDaysLeft(this.repository, this.strategy);
+
+  /// [inventory] の残量がなくなるまでの日数を返す
+  Future<int> call(Inventory inventory) async {
+    final history = await repository.watchHistory(inventory.id).first;
+    double quantity = 0;
+    for (final h in history.reversed) {
+      if (h.type == 'stocktake') {
+        quantity = h.after;
+      } else if (h.type == 'add' || h.type == 'bought') {
+        quantity += h.quantity;
+      } else if (h.type == 'used') {
+        quantity -= h.quantity;
+      }
+    }
+    final predicted = strategy.predict(DateTime.now(), history, quantity);
+    return predicted.difference(DateTime.now()).inDays;
+  }
+}

--- a/test/calculate_days_left_test.dart
+++ b/test/calculate_days_left_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oouchi_stock/domain/entities/history_entry.dart';
+import 'package:oouchi_stock/domain/entities/inventory.dart';
+import 'package:oouchi_stock/domain/usecases/calculate_days_left.dart';
+import 'package:oouchi_stock/domain/repositories/inventory_repository.dart';
+import 'package:oouchi_stock/domain/services/purchase_prediction_strategy.dart';
+
+class FakeInventoryRepository implements InventoryRepository {
+  List<HistoryEntry> history = [];
+
+  @override
+  Stream<List<HistoryEntry>> watchHistory(String inventoryId) async* {
+    yield history;
+  }
+
+  // 以下のメソッドはテストでは使用しない
+  @override
+  Stream<List<Inventory>> watchByCategory(String category) => throw UnimplementedError();
+  @override
+  Future<List<Inventory>> fetchAll() => throw UnimplementedError();
+  @override
+  Future<String> addInventory(Inventory inventory) => throw UnimplementedError();
+  @override
+  Future<void> updateQuantity(String id, double amount, String type) => throw UnimplementedError();
+  @override
+  Future<void> updateInventory(Inventory inventory) => throw UnimplementedError();
+  @override
+  Stream<Inventory?> watchInventory(String inventoryId) => throw UnimplementedError();
+  @override
+  Future<void> stocktake(String id, double before, double after, double diff) => throw UnimplementedError();
+  @override
+  Future<void> deleteInventory(String id) => throw UnimplementedError();
+  @override
+  Stream<List<Inventory>> watchNeedsBuy(double threshold) => throw UnimplementedError();
+}
+
+class FakeStrategy implements PurchasePredictionStrategy {
+  int called = 0;
+  @override
+  DateTime predict(DateTime now, List<HistoryEntry> history, double quantity) {
+    called++;
+    return now.add(Duration(days: quantity.toInt()));
+  }
+}
+
+void main() {
+  test('履歴から残り日数を計算する', () async {
+    final repo = FakeInventoryRepository();
+    repo.history = [
+      HistoryEntry('add', 2, DateTime(2023,1,1)),
+      HistoryEntry('used', 1, DateTime(2023,1,2)),
+    ];
+    final strategy = FakeStrategy();
+    final usecase = CalculateDaysLeft(repo, strategy);
+    final inv = Inventory(
+        id: '1',
+        itemName: 'test',
+        category: 'cat',
+        itemType: 'type',
+        quantity: 1,
+        unit: '個',
+        createdAt: DateTime.now());
+    final days = await usecase(inv);
+    expect(days, 1); // FakeStrategy は quantity 分の日数を返す
+    expect(strategy.called, 1);
+  });
+}


### PR DESCRIPTION
## 概要
- ホーム画面の残り日数計算を `CalculateDaysLeft` ユースケースとして分離
- 在庫一覧取得に `FetchAllInventory` ユースケースを利用
- 上記変更を説明するドキュメント更新
- ユースケースの単体テスト追加

## テスト結果
- `flutter test` は環境に Flutter が無いため実行できず


------
https://chatgpt.com/codex/tasks/task_e_685555b228dc832ea333a99ff209ba7e