### PR TITLE
fix MyAppState reference

### DIFF
--- a/lib/buy_list_page.dart
+++ b/lib/buy_list_page.dart
@@ -18,6 +18,8 @@ import 'inventory_detail_page.dart';
 import 'widgets/inventory_card.dart';
 import 'domain/entities/category_order.dart';
 import 'widgets/settings_menu_button.dart';
+// 言語変更時にアプリ全体のロケールを更新するため MyAppState を参照
+import 'main.dart';
 
 /// 買い物予報画面
 /// ホーム画面のメニューから遷移し、今買っておいた方が良い商品を表示する
@@ -126,7 +128,9 @@ class _BuyListPageState extends State<BuyListPage> {
                 SettingsMenuButton(
                   categories: _categories,
                   onCategoriesChanged: _updateCategories,
-                  onLocaleChanged: (l) => context.findAncestorStateOfType<MyAppState>()?.updateLocale(l),
+                  // 設定画面で言語を変更したときにアプリ全体のロケールを更新する
+                  onLocaleChanged: (l) =>
+                      context.findAncestorStateOfType<MyAppState>()?.updateLocale(l),
                   onConditionChanged: _load,
                 )
               ],


### PR DESCRIPTION
## Summary
- MyAppState を参照するため buy_list_page.dart に main.dart をインポート
- 言語変更時のロケール更新処理にコメントを追加

## Testing
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685577c41c20832e9972d1912c1df3c2