### PR TITLE
Fix Timestamp parsing issue

### DIFF
--- a/lib/add_inventory_page.dart
+++ b/lib/add_inventory_page.dart
@@ -4,6 +4,7 @@ import 'package:oouchi_stock/i18n/app_localizations.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'util/firestore_refs.dart';
+import 'util/date_time_parser.dart';
 import 'domain/entities/inventory.dart';
 import 'domain/entities/category.dart';
 import 'default_item_types.dart';
@@ -82,7 +83,7 @@ class _AddInventoryPageState extends State<AddInventoryPage> {
             return Category(
               id: data['id'] ?? 0,
               name: data['name'] ?? '',
-              createdAt: (data['createdAt'] as Timestamp).toDate(),
+              createdAt: parseDateTime(data['createdAt']),
               color: data['color'],
             );
           }).toList();

--- a/lib/buy_list_page.dart
+++ b/lib/buy_list_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'util/firestore_refs.dart';
+import 'util/date_time_parser.dart';
 import 'package:oouchi_stock/i18n/app_localizations.dart';
 import 'data/repositories/buy_list_repository_impl.dart';
 import 'domain/entities/buy_item.dart';
@@ -70,7 +71,7 @@ class _BuyListPageState extends State<BuyListPage> {
         return Category(
           id: data['id'] ?? 0,
           name: data['name'] ?? '',
-          createdAt: (data['createdAt'] as Timestamp).toDate(),
+          createdAt: parseDateTime(data['createdAt']),
           color: data['color'],
         );
       }).toList();

--- a/lib/category_settings_page.dart
+++ b/lib/category_settings_page.dart
@@ -3,6 +3,7 @@ import 'package:oouchi_stock/i18n/app_localizations.dart';
 import 'dart:async';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'util/firestore_refs.dart';
+import 'util/date_time_parser.dart';
 import 'add_category_page.dart';
 import 'edit_category_page.dart';
 import 'reorder_categories_page.dart';
@@ -40,7 +41,7 @@ class _CategorySettingsPageState extends State<CategorySettingsPage> {
         return Category(
           id: data['id'] ?? 0,
           name: data['name'] ?? '',
-          createdAt: (data['createdAt'] as Timestamp).toDate(),
+          createdAt: parseDateTime(data['createdAt']),
           color: data['color'],
         );
       }).toList();

--- a/lib/data/repositories/inventory_repository_impl.dart
+++ b/lib/data/repositories/inventory_repository_impl.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../util/firestore_refs.dart';
+import '../../util/date_time_parser.dart';
 
 import '../../domain/entities/inventory.dart';
 import '../../domain/entities/history_entry.dart';
@@ -26,7 +27,7 @@ class InventoryRepositoryImpl implements InventoryRepository {
                 quantity: (data['quantity'] ?? 0).toDouble(),
                 unit: data['unit'] ?? '',
                 note: data['note'] ?? '',
-                createdAt: (data['createdAt'] as Timestamp).toDate(),
+                createdAt: parseDateTime(data['createdAt']),
               );
             }).toList());
   }
@@ -46,7 +47,7 @@ class InventoryRepositoryImpl implements InventoryRepository {
         quantity: (data['quantity'] ?? 0).toDouble(),
         unit: data['unit'] ?? '',
         note: data['note'] ?? '',
-        createdAt: (data['createdAt'] as Timestamp).toDate(),
+        createdAt: parseDateTime(data['createdAt']),
       );
     }).toList();
   }
@@ -108,7 +109,7 @@ class InventoryRepositoryImpl implements InventoryRepository {
         quantity: (data['quantity'] ?? 0).toDouble(),
         unit: data['unit'] ?? '',
         note: data['note'] ?? '',
-        createdAt: (data['createdAt'] as Timestamp).toDate(),
+        createdAt: parseDateTime(data['createdAt']),
       );
     });
   }
@@ -169,7 +170,7 @@ class InventoryRepositoryImpl implements InventoryRepository {
                 quantity: (data['quantity'] ?? 0).toDouble(),
                 unit: data['unit'] ?? '',
                 note: data['note'] ?? '',
-                createdAt: (data['createdAt'] as Timestamp).toDate(),
+                createdAt: parseDateTime(data['createdAt']),
               );
             }).toList());
   }

--- a/lib/edit_inventory_page.dart
+++ b/lib/edit_inventory_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:oouchi_stock/i18n/app_localizations.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'util/firestore_refs.dart';
+import 'util/date_time_parser.dart';
 import 'domain/entities/inventory.dart';
 import 'domain/entities/category.dart';
 import 'domain/usecases/update_inventory.dart';
@@ -68,7 +69,7 @@ class _EditInventoryPageState extends State<EditInventoryPage> {
           return Category(
             id: data['id'] ?? 0,
             name: data['name'] ?? '',
-            createdAt: (data['createdAt'] as Timestamp).toDate(),
+            createdAt: parseDateTime(data['createdAt']),
             color: data['color'],
           );
         }).toList();

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'util/firestore_refs.dart';
+import 'util/date_time_parser.dart';
 import 'package:oouchi_stock/i18n/app_localizations.dart';
 import 'add_inventory_page.dart';
 import 'add_category_page.dart';
@@ -103,7 +104,7 @@ class _HomePageState extends State<HomePage> {
           return Category(
             id: data['id'] ?? 0,
             name: data['name'] ?? '',
-            createdAt: (data['createdAt'] as Timestamp).toDate(),
+            createdAt: parseDateTime(data['createdAt']),
           );
         }).toList();
         list = await applyCategoryOrder(list);

--- a/lib/inventory_page.dart
+++ b/lib/inventory_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'util/firestore_refs.dart';
+import 'util/date_time_parser.dart';
 import 'package:oouchi_stock/i18n/app_localizations.dart';
 import 'add_inventory_page.dart';
 import 'add_category_page.dart';
@@ -70,7 +71,7 @@ class _InventoryPageState extends State<InventoryPage> {
           return Category(
             id: data['id'] ?? 0,
             name: data['name'] ?? '',
-            createdAt: (data['createdAt'] as Timestamp).toDate(),
+            createdAt: parseDateTime(data['createdAt']),
             color: data['color'],
           );
         }).toList();

--- a/lib/item_type_settings_page.dart
+++ b/lib/item_type_settings_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'util/firestore_refs.dart';
+import 'util/date_time_parser.dart';
 
 import 'domain/entities/item_type.dart';
 import 'domain/entities/category.dart';
@@ -46,7 +47,7 @@ class _ItemTypeSettingsPageState extends State<ItemTypeSettingsPage> {
             id: data['id'] ?? 0,
             category: data['category'] ?? '',
             name: data['name'] ?? '',
-            createdAt: (data['createdAt'] as Timestamp).toDate(),
+            createdAt: parseDateTime(data['createdAt']),
           );
         }).toList();
       });

--- a/lib/price_list_page.dart
+++ b/lib/price_list_page.dart
@@ -3,6 +3,7 @@ import 'package:oouchi_stock/i18n/app_localizations.dart';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'util/firestore_refs.dart';
+import 'util/date_time_parser.dart';
 
 import 'add_price_page.dart';
 import 'add_inventory_page.dart';
@@ -41,7 +42,7 @@ class _PriceListPageState extends State<PriceListPage> {
         return Category(
           id: data['id'] ?? 0,
           name: data['name'] ?? '',
-          createdAt: (data['createdAt'] as Timestamp).toDate(),
+          createdAt: parseDateTime(data['createdAt']),
         );
       }).toList();
       list = await applyCategoryOrder(list);

--- a/lib/util/date_time_parser.dart
+++ b/lib/util/date_time_parser.dart
@@ -1,0 +1,8 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Firestore の Timestamp または ISO8601 形式の文字列から DateTime を生成するヘルパー
+DateTime parseDateTime(dynamic value) {
+  if (value is Timestamp) return value.toDate();
+  if (value is String) return DateTime.tryParse(value) ?? DateTime.now();
+  return DateTime.now();
+}

--- a/test/date_time_parser_test.dart
+++ b/test/date_time_parser_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:oouchi_stock/util/date_time_parser.dart';
+
+void main() {
+  test('Timestamp と String から DateTime を解析できる', () {
+    final date = DateTime(2020, 1, 1);
+    final ts = Timestamp.fromDate(date);
+    expect(parseDateTime(ts), date);
+    expect(parseDateTime('2020-01-02T00:00:00.000'), DateTime(2020, 1, 2));
+  });
+}


### PR DESCRIPTION
## Summary
- FirestoreのcreatedAtフィールドが文字列の場合に対応する`parseDateTime`を追加
- 各画面・リポジトリで`parseDateTime`を使用するよう更新
- テストを追加

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68557d07522c832e86607f03178b4bc7