### PR TITLE
データが空の時の例外回避

### DIFF
--- a/lib/add_category_page.dart
+++ b/lib/add_category_page.dart
@@ -45,6 +45,8 @@ class _AddCategoryPageState extends State<AddCategoryPage> {
           .closed;
       if (mounted) Navigator.pop(context);
     } catch (e) {
+      // 例外内容をログに出力
+      debugPrint('カテゴリ保存失敗: $e');
       if (mounted) {
         ScaffoldMessenger.of(context)
             .showSnackBar(SnackBar(content: Text(AppLocalizations.of(context)!.saveFailed)));

--- a/lib/add_inventory_page.dart
+++ b/lib/add_inventory_page.dart
@@ -278,6 +278,8 @@ class _AddInventoryPageState extends State<AddInventoryPage> {
                         });
                       }
                     } on FirebaseException catch (e) {
+                      // Firestore からの例外をログに出力
+                      debugPrint('在庫保存失敗: ${e.message ?? e.code}');
                       if (mounted) {
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(
@@ -286,7 +288,9 @@ class _AddInventoryPageState extends State<AddInventoryPage> {
                           ),
                         );
                       }
-                    } catch (_) {
+                    } catch (e) {
+                      // その他の例外をログに出力
+                      debugPrint('在庫保存失敗: $e');
                       if (mounted) {
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(content: Text(AppLocalizations.of(context)!.saveFailed)),

--- a/lib/add_item_type_page.dart
+++ b/lib/add_item_type_page.dart
@@ -41,7 +41,9 @@ class _AddItemTypePageState extends State<AddItemTypePage> {
           .showSnackBar(SnackBar(content: Text(AppLocalizations.of(context)!.saved)))
           .closed;
       if (mounted) Navigator.pop(context);
-    } catch (_) {
+    } catch (e) {
+      // エラー内容をログに出力
+      debugPrint('品種保存失敗: $e');
       if (mounted) {
         ScaffoldMessenger.of(context)
             .showSnackBar(SnackBar(content: Text(AppLocalizations.of(context)!.saveFailed)));

--- a/lib/add_price_page.dart
+++ b/lib/add_price_page.dart
@@ -170,11 +170,13 @@ class _AddPricePageState extends State<AddPricePage> {
                           try {
                             await _save();
                             if (!mounted) return;
-                            await ScaffoldMessenger.of(context)
-                                .showSnackBar(SnackBar(content: Text(AppLocalizations.of(context)!.saved)))
-                                .closed;
-                            if (mounted) Navigator.pop(context);
-                          } catch (_) {
+                          await ScaffoldMessenger.of(context)
+                              .showSnackBar(SnackBar(content: Text(AppLocalizations.of(context)!.saved)))
+                              .closed;
+                          if (mounted) Navigator.pop(context);
+                          } catch (e) {
+                            // 例外をログに出力
+                            debugPrint('セール情報保存失敗: $e');
                             if (mounted) {
                               ScaffoldMessenger.of(context)
                                   .showSnackBar(SnackBar(content: Text(AppLocalizations.of(context)!.saveFailed)));

--- a/lib/edit_item_type_page.dart
+++ b/lib/edit_item_type_page.dart
@@ -29,10 +29,13 @@ class _EditItemTypePageState extends State<EditItemTypePage> {
   void initState() {
     super.initState();
     _name = widget.itemType.name;
-    _category = widget.categories.firstWhere(
-      (c) => c.name == widget.itemType.category,
-      orElse: () => widget.categories.first,
-    );
+    // 画面初期化時に現在のカテゴリを設定
+    if (widget.categories.isNotEmpty) {
+      _category = widget.categories.firstWhere(
+        (c) => c.name == widget.itemType.category,
+        orElse: () => widget.categories.first,
+      );
+    }
   }
 
   Future<void> _save() async {

--- a/lib/item_type_settings_page.dart
+++ b/lib/item_type_settings_page.dart
@@ -76,7 +76,9 @@ class _ItemTypeSettingsPageState extends State<ItemTypeSettingsPage> {
           SnackBar(content: Text(AppLocalizations.of(context)!.deleted)),
         );
       }
-    } catch (_) {
+    } catch (e) {
+      // 例外内容をログに出力
+      debugPrint('品種削除失敗: $e');
       if (mounted) {
         // 削除失敗を通知
         ScaffoldMessenger.of(context).showSnackBar(
@@ -137,6 +139,13 @@ class _ItemTypeSettingsPageState extends State<ItemTypeSettingsPage> {
 
   @override
   Widget build(BuildContext context) {
+    // カテゴリが存在しない場合は登録を促す画面を表示
+    if (widget.categories.isEmpty) {
+      return Scaffold(
+        appBar: AppBar(title: Text(AppLocalizations.of(context)!.itemTypeSettingsTitle)),
+        body: Center(child: Text(AppLocalizations.of(context)!.addCategory)),
+      );
+    }
     return DefaultTabController(
       // カテゴリ数だけタブを生成
       length: widget.categories.length,

--- a/lib/price_list_page.dart
+++ b/lib/price_list_page.dart
@@ -7,6 +7,7 @@ import 'util/date_time_parser.dart';
 
 import 'add_price_page.dart';
 import 'add_inventory_page.dart';
+import 'add_category_page.dart';
 import 'settings_page.dart';
 import 'widgets/settings_menu_button.dart';
 import 'data/repositories/price_repository_impl.dart';
@@ -65,6 +66,23 @@ class _PriceListPageState extends State<PriceListPage> {
       return Scaffold(
         appBar: AppBar(title: Text(AppLocalizations.of(context)!.priceManagementTitle)),
         body: const Center(child: CircularProgressIndicator()),
+      );
+    }
+    // カテゴリが存在しない場合は追加を促す画面を表示
+    if (_categories.isEmpty) {
+      return Scaffold(
+        appBar: AppBar(title: Text(AppLocalizations.of(context)!.priceManagementTitle)),
+        body: Center(
+          child: ElevatedButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const AddCategoryPage()),
+              );
+            },
+            child: Text(AppLocalizations.of(context)!.addCategory),
+          ),
+        ),
       );
     }
     return DefaultTabController(

--- a/test/price_list_page_test.dart
+++ b/test/price_list_page_test.dart
@@ -3,14 +3,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:oouchi_stock/price_list_page.dart';
 
 void main() {
-  testWidgets('PriceListPage 初期表示', (WidgetTester tester) async {
+  testWidgets('カテゴリがない場合は追加ボタンを表示', (WidgetTester tester) async {
     await tester.pumpWidget(const MaterialApp(home: PriceListPage()));
-    expect(find.byType(AppBar), findsOneWidget);
-    // 検索バーが表示されるか確認
-    expect(find.byType(TextField), findsWidgets);
-    // 表の列数が6であることを確認
-    final dataTable = tester.widget<DataTable>(find.byType(DataTable).first);
-    expect(dataTable.columns.length, 6);
+    await tester.pumpAndSettle();
+    expect(find.byType(ElevatedButton), findsOneWidget);
   });
 
   testWidgets('設定メニューが表示される', (WidgetTester tester) async {


### PR DESCRIPTION
## Summary
- カテゴリが無い場合の画面遷移を追加
- アイテム種別編集画面の初期化処理を修正
- Firestore 操作失敗時にデバッグ出力を追加
- テストを更新

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855e1602f94832e933fa4aa1163e526