### PR TITLE
履歴タイルのスタイル改善

### DIFF
--- a/lib/inventory_detail_page.dart
+++ b/lib/inventory_detail_page.dart
@@ -188,23 +188,25 @@ class InventoryDetailPage extends StatelessWidget {
     final quantityText =
         '${e.before.toStringAsFixed(1)} -> ${e.after.toStringAsFixed(1)} ($diffSign${e.diff.abs().toStringAsFixed(1)}$unit)';
     final color = e.diff >= 0 ? Colors.green : Colors.red;
+    // 履歴の表示文字サイズをカテゴリ表示と合わせる
+    const style = TextStyle(fontSize: 18);
 
     return Column(
       children: [
         Row(
           children: [
-            Expanded(child: Text(_formatDate(e.timestamp))),
-            Expanded(child: Center(child: Text(_typeLabel(e.type)))),
+            Expanded(child: Text(_formatDate(e.timestamp), style: style)),
+            Expanded(child: Center(child: Text(_typeLabel(e.type), style: style))),
             Expanded(
               child: Text(
                 quantityText,
                 textAlign: TextAlign.right,
-                style: TextStyle(color: color),
+                style: style.copyWith(color: color),
               ),
             ),
           ],
         ),
-        const Divider(height: 1),
+        Divider(height: 1, color: Colors.grey.shade300),
       ],
     );
   }

--- a/test/inventory_detail_page_test.dart
+++ b/test/inventory_detail_page_test.dart
@@ -101,4 +101,21 @@ void main() {
     expect(find.text('1.0個'), findsOneWidget);
     expect(find.text('追加'), findsOneWidget);
   });
+
+  testWidgets('履歴タイルのスタイルを確認', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: InventoryDetailPage(
+        inventoryId: '1',
+        categories: [Category(id: 1, name: '日用品', createdAt: DateTime.now())],
+        repository: _DataRepository(),
+      ),
+    ));
+    await tester.pump();
+
+    final text = tester.widget<Text>(find.text('追加'));
+    expect(text.style?.fontSize, 18);
+
+    final divider = tester.widget<Divider>(find.byType(Divider).first);
+    expect(divider.color, Colors.grey.shade300);
+  });
 }


### PR DESCRIPTION
## Summary
- 履歴タイルのテキストを18spに統一しDividerを薄いグレーへ変更
- 変更に合わせたウィジェットテストを追加

## Testing
- `flutter test` *(fails: flutter command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ffa71344832ead8b2ca3edb2c143