### PR TITLE
predictLabel 文言更新

### DIFF
--- a/lib/i18n/app_en.arb
+++ b/lib/i18n/app_en.arb
@@ -42,7 +42,7 @@
   "boughtAmount": "Bought amount",
   "stockAmount": "Current stock",
   "updateFailed": "Update failed",
-  "predictLabel": "Prediction:",
+  "predictLabel": "Prediction",
   "daysLeft": "in {value} days",
   "calculating": "Calculating...",
   "history": "History",

--- a/lib/i18n/app_ja.arb
+++ b/lib/i18n/app_ja.arb
@@ -42,7 +42,7 @@
   "boughtAmount": "買った量",
   "stockAmount": "現在の在庫",
   "updateFailed": "更新に失敗しました",
-  "predictLabel": "予測:",
+  "predictLabel": "予測",
   "daysLeft": "あと{value}日",
   "calculating": "計算中...",
   "history": "履歴",

--- a/lib/inventory_detail_page.dart
+++ b/lib/inventory_detail_page.dart
@@ -12,9 +12,13 @@ import 'edit_inventory_page.dart';
 
 // 商品詳細画面。履歴と予測日を表示する
 class InventoryDetailPage extends StatelessWidget {
+  /// 表示対象の在庫ID
   final String inventoryId;
+  /// カテゴリ一覧
   final List<Category> categories;
+  /// 購入予測計算用ストラテジー
   final PurchasePredictionStrategy strategy;
+  /// 在庫リポジトリ
   final InventoryRepository repository;
 
   InventoryDetailPage({
@@ -25,10 +29,12 @@ class InventoryDetailPage extends StatelessWidget {
     InventoryRepository? repository,
   }) : repository = repository ?? InventoryRepositoryImpl();
 
+  /// 指定IDの在庫を監視するストリームを返す
   Stream<Inventory?> inventoryStream() {
     return repository.watchInventory(inventoryId);
   }
 
+  /// 在庫履歴を監視するストリームを返す
   Stream<List<HistoryEntry>> historyStream() {
     return repository.watchHistory(inventoryId);
   }
@@ -57,6 +63,7 @@ class InventoryDetailPage extends StatelessWidget {
         }
         return Scaffold(
           appBar: AppBar(title: Text(inv.itemName), actions: [
+            // 編集ボタン。押すと編集画面へ遷移する
             IconButton(
               icon: const Icon(Icons.edit),
               onPressed: () {
@@ -141,6 +148,7 @@ class InventoryDetailPage extends StatelessWidget {
     );
   }
 
+  /// 履歴から現在の在庫数を計算する
   double _currentQuantity(List<HistoryEntry> history) {
     if (history.isEmpty) return 0;
     double total = 0;

--- a/test/inventory_detail_page_test.dart
+++ b/test/inventory_detail_page_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:oouchi_stock/inventory_detail_page.dart';
+import 'package:oouchi_stock/i18n/app_localizations.dart';
 import 'package:oouchi_stock/domain/entities/category.dart';
 import 'package:oouchi_stock/domain/entities/inventory.dart';
 import 'package:oouchi_stock/domain/entities/history_entry.dart';
@@ -67,6 +68,9 @@ class _DataRepository extends _FakeRepository {
 void main() {
   testWidgets('InventoryDetailPage ローディング表示', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('ja'),
       home: InventoryDetailPage(
         inventoryId: '1',
         categories: [Category(id: 1, name: '日用品', createdAt: DateTime.now())],
@@ -77,6 +81,9 @@ void main() {
 
   testWidgets('データが取得できない場合にエラー表示', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('ja'),
       home: InventoryDetailPage(
         inventoryId: '1',
         categories: [Category(id: 1, name: '日用品', createdAt: DateTime.now())],
@@ -89,6 +96,9 @@ void main() {
 
   testWidgets('詳細情報が左右に表示される', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('ja'),
       home: InventoryDetailPage(
         inventoryId: '1',
         categories: [Category(id: 1, name: '日用品', createdAt: DateTime.now())],
@@ -100,5 +110,6 @@ void main() {
     expect(find.text('一般'), findsOneWidget);
     expect(find.text('1.0個'), findsOneWidget);
     expect(find.text('追加'), findsOneWidget);
+    expect(find.text('予測'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- i18nのpredictLabelを日本語では「予測」、英語では「Prediction」に変更
- InventoryDetailPageの各メンバやイベントに日本語コメントを追加
- テストをローカライズ対応し、ラベル変更を確認

## Testing
- `flutter gen-l10n` *(failed: command not found)*
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ffaab2a4832ebc329c82bdd4b283