### PR TITLE
ビルドエラーの修正

### DIFF
--- a/lib/buy_list_page.dart
+++ b/lib/buy_list_page.dart
@@ -34,7 +34,7 @@ class BuyListPage extends StatefulWidget {
   /// 在庫データ取得用リポジトリ
   final InventoryRepository repository;
 
-  const BuyListPage({
+  BuyListPage({
     super.key,
     this.categories,
     InventoryRepository? repository,

--- a/lib/price_history_page.dart
+++ b/lib/price_history_page.dart
@@ -13,6 +13,8 @@ class PriceHistoryPage extends StatelessWidget {
   final String category;
   /// 品種名
   final String itemType;
+  /// 商品名 (null なら品種名をタイトルに表示)
+  final String? itemName;
   /// セール情報取得ユースケース
   final WatchPriceByType _watch;
   /// セール情報削除ユースケース
@@ -23,6 +25,7 @@ class PriceHistoryPage extends StatelessWidget {
     super.key,
     required this.category,
     required this.itemType,
+    this.itemName,
     WatchPriceByType? watch,
     DeletePriceInfo? deleter,
   })  : _watch = watch ?? WatchPriceByType(PriceRepositoryImpl()),
@@ -33,8 +36,8 @@ class PriceHistoryPage extends StatelessWidget {
     final textStyle =
         Theme.of(context).textTheme.bodyLarge?.copyWith(fontSize: 18);
     return Scaffold(
-      // 商品名をタイトルに表示
-      appBar: AppBar(title: Text(itemName)),
+      // 商品名が指定されていればタイトルに表示、無ければ品種名を表示
+      appBar: AppBar(title: Text(itemName ?? itemType)),
       body: StreamBuilder<List<PriceInfo>>(
         stream: _watch(category, itemType),
         builder: (context, snapshot) {
@@ -75,6 +78,7 @@ class PriceHistoryPage extends StatelessWidget {
                         children: [
                           _buildRow(loc.category, p.category),
                           _buildRow(loc.itemType, p.itemType),
+                          _buildRow(loc.itemName, p.itemName),
                           _buildRow(loc.checkedDate(_formatDate(p.checkedAt)), ''),
                           _buildRow(loc.expiry(_formatDate(p.expiry)), ''),
                           _buildRow(loc.count, '${p.count} ${p.unit}'),
@@ -105,7 +109,7 @@ class PriceHistoryPage extends StatelessWidget {
   }
 
   /// 項目名と値を左右に表示する行を作成する
-  Widget _buildRow(String label, String value, TextStyle? style) {
+  Widget _buildRow(String label, String value, [TextStyle? style]) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),
       child: Row(

--- a/test/price_history_page_test.dart
+++ b/test/price_history_page_test.dart
@@ -8,7 +8,7 @@ import 'package:oouchi_stock/domain/usecases/watch_price_by_type.dart';
 
 void main() {
   testWidgets('PriceHistoryPage が表示される', (WidgetTester tester) async {
-    await tester.pumpWidget(const MaterialApp(
+    await tester.pumpWidget(MaterialApp(
       home: PriceHistoryPage(
         category: '日用品',
         itemType: '洗剤',


### PR DESCRIPTION
## Summary
- BuyListPage で `const` コンストラクタを削除し、非 const インスタンスを許可
- PriceHistoryPage に `itemName` パラメータを追加してタイトル表示を修正
- PriceHistoryPage の `_buildRow` を省略可能な引数に変更
- PriceHistoryPage の表示項目に商品名を追加
- それに合わせてテストコードを更新

## Testing
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68560241315c832e98f4fed36cd4bad1