### PR TITLE
ビルドエラー解消

### DIFF
--- a/lib/root_navigation_page.dart
+++ b/lib/root_navigation_page.dart
@@ -27,7 +27,8 @@ class _RootNavigationPageState extends State<RootNavigationPage> {
   // 3: 商品追加画面
   // 4: セール情報追加画面
   late final List<Widget> _pages = [
-    const BuyListPage(),
+    // 非 const コンストラクタのため const を付けない
+    BuyListPage(),
     const InventoryPage(),
     const HomePage(),
     const AddInventoryPage(),


### PR DESCRIPTION
## Summary
- RootNavigationPage の `_pages` 初期化で BuyListPage を const で呼び出さないよう修正しました。

## Testing
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856034c6290832ea560874a68281047