### PR TITLE
カテゴリ追加後のリスト更新を修正

### DIFF
--- a/lib/add_inventory_page.dart
+++ b/lib/add_inventory_page.dart
@@ -72,13 +72,14 @@ class _AddInventoryPageState extends State<AddInventoryPage> {
   @override
   void initState() {
     super.initState();
-    if (widget.categories != null) {
+    // 引数にカテゴリが渡されており、かつ件数が1件以上ある場合のみ
+    if (widget.categories != null && widget.categories!.isNotEmpty) {
+      // 画面初期化時にカテゴリリストを設定
       _categories = List.from(widget.categories!);
-      if (_categories.isNotEmpty) {
-        _category = _categories.first;
-      }
+      _category = _categories.first;
       _categoriesLoaded = true;
     } else {
+      // カテゴリが無い場合は Firestore を監視して更新を待つ
       _catSub = userCollection('categories')
           .orderBy('createdAt')
           .snapshots()

--- a/lib/buy_list_page.dart
+++ b/lib/buy_list_page.dart
@@ -122,11 +122,13 @@ class _BuyListPageState extends State<BuyListPage> {
 
   // BuyListPage 起動時に呼び出し、カテゴリ一覧と条件設定を読み込む
   Future<void> _load() async {
-    if (widget.categories != null) {
+    // カテゴリが渡されており、件数が 1 件以上の場合のみそのまま使用
+    if (widget.categories != null && widget.categories!.isNotEmpty) {
       // 設定画面から受け取ったカテゴリを並び順付きで保持
       _categories = List.from(widget.categories!);
       _categories = await applyCategoryOrder(_categories);
     } else {
+      // カテゴリが空の場合は Firestore から取得
       final snapshot = await userCollection('categories')
           .orderBy('createdAt')
           .get();

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -79,7 +79,8 @@ class _HomePageState extends State<HomePage> {
   void initState() {
     super.initState();
     _loadCondition();
-    if (widget.categories != null) {
+    // 引数でカテゴリが渡され、1件以上存在する場合のみ利用する
+    if (widget.categories != null && widget.categories!.isNotEmpty) {
       _categories = List.from(widget.categories!);
       applyCategoryOrder(_categories).then((list) {
         setState(() {
@@ -88,6 +89,7 @@ class _HomePageState extends State<HomePage> {
         });
       });
     } else {
+      // カテゴリが空の場合は Firestore を監視して更新を待つ
       // Firestore からカテゴリ一覧を取得して監視
       // カテゴリに変更があったときに実行される
       _catSub = userCollection('categories')

--- a/lib/inventory_page.dart
+++ b/lib/inventory_page.dart
@@ -49,7 +49,8 @@ class _InventoryPageState extends State<InventoryPage> {
   @override
   void initState() {
     super.initState();
-    if (widget.categories != null) {
+    // 引数のカテゴリが存在し、件数が 1 件以上の場合のみ使用する
+    if (widget.categories != null && widget.categories!.isNotEmpty) {
       _categories = List.from(widget.categories!);
       applyCategoryOrder(_categories).then((list) {
         setState(() {
@@ -58,6 +59,7 @@ class _InventoryPageState extends State<InventoryPage> {
         });
       });
     } else {
+      // カテゴリが空の場合は Firestore を監視して更新を待つ
       // Firestore からカテゴリ一覧を取得して監視
       _catSub = userCollection('categories')
           .orderBy('createdAt')


### PR DESCRIPTION
## Summary
- カテゴリが空の状態で追加しても画面に反映されない問題を修正
- AddInventoryPage, InventoryPage, HomePage, BuyListPage でカテゴリ監視処理を改善

## Testing
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685629cf1b9c832e9957413c0163c66b