### PR TITLE
Fix Hero tag duplication for FABs

### DIFF
--- a/lib/category_settings_page.dart
+++ b/lib/category_settings_page.dart
@@ -163,6 +163,8 @@ class _CategorySettingsPageState extends State<CategorySettingsPage> {
         ],
       ),
       floatingActionButton: FloatingActionButton(
+        // カテゴリ設定画面専用のヒーロータグ
+        heroTag: 'categoryFab',
         onPressed: () async {
           await Navigator.push(
             context,

--- a/lib/inventory_page.dart
+++ b/lib/inventory_page.dart
@@ -176,6 +176,8 @@ class InventoryPageState extends State<InventoryPage> {
           ),
           // 画面右下のプラスボタンを押すと商品追加画面を開く
           floatingActionButton: FloatingActionButton(
+            // 在庫一覧画面専用のヒーロータグ
+            heroTag: 'inventoryFab',
             onPressed: () {
               Navigator.push(
                 context,

--- a/lib/item_type_settings_page.dart
+++ b/lib/item_type_settings_page.dart
@@ -169,6 +169,8 @@ class _ItemTypeSettingsPageState extends State<ItemTypeSettingsPage> {
           ],
         ),
         floatingActionButton: FloatingActionButton(
+          // 品種設定画面専用のヒーロータグ
+          heroTag: 'itemTypeFab',
           onPressed: () async {
             await Navigator.push(
               context,

--- a/lib/price_list_page.dart
+++ b/lib/price_list_page.dart
@@ -126,6 +126,8 @@ class _PriceListPageState extends State<PriceListPage> {
           ],
         ),
         floatingActionButton: FloatingActionButton(
+          // セール情報管理画面専用のヒーロータグ
+          heroTag: 'priceListFab',
           onPressed: () {
             // セール情報追加画面を開く
             Navigator.push(


### PR DESCRIPTION
## Summary
- FABのHeroタグが重複しないよう、各画面に固有のタグを設定しました

## Testing
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856bcb8fa10832eb6128ecd053eeeb0