### PR TITLE
カードウィジェットの分離

### DIFF
--- a/docs/architecture_proposals_ja.md
+++ b/docs/architecture_proposals_ja.md
@@ -6,6 +6,8 @@
 - 画面内のコンポーネントを小さな StatelessWidget / StatefulWidget として切り出し、`lib/widgets` 配下に配置します。
 - これによりファイル単位で役割が明確になり、テストもしやすくなります。
 - 例として `InventoryCard` を `lib/widgets/inventory_card.dart` へ分離しました。
+- 買い物予報画面の `PredictionCard` やセール情報画面の `SaleItemCard` も
+- 同様に `lib/widgets` 配下へ切り出しています。
 - 同様に `main.dart` にあったホーム画面と在庫画面を
   `lib/home_page.dart` と `lib/inventory_page.dart` に切り出しています。
 - 論理処理は可能な限り UseCase として切り出します。例えば

--- a/lib/models/sale_item.dart
+++ b/lib/models/sale_item.dart
@@ -1,0 +1,33 @@
+/// セール情報を表すデータモデル
+class SaleItem {
+  /// 商品名
+  final String name;
+  /// 店舗名
+  final String shop;
+  /// 通常価格
+  final double regularPrice;
+  /// セール価格
+  final double salePrice;
+  /// セール開始日
+  final DateTime start;
+  /// セール終了日
+  final DateTime end;
+  /// 在庫数
+  final int stock;
+  /// おすすめフラグ
+  final bool recommended;
+  /// 最安値フラグ
+  final bool lowest;
+
+  SaleItem({
+    required this.name,
+    required this.shop,
+    required this.regularPrice,
+    required this.salePrice,
+    required this.start,
+    required this.end,
+    required this.stock,
+    this.recommended = false,
+    this.lowest = false,
+  });
+}

--- a/lib/sale_list_page.dart
+++ b/lib/sale_list_page.dart
@@ -3,31 +3,9 @@ import 'i18n/app_localizations.dart';
 import 'data/repositories/buy_list_repository_impl.dart';
 import 'domain/entities/buy_item.dart';
 import 'domain/usecases/add_buy_item.dart';
-
-/// セール情報1件分のデータモデル
-class SaleItem {
-  final String name; // 商品名
-  final String shop; // 店舗名
-  final double regularPrice; // 通常価格
-  final double salePrice; // セール価格
-  final DateTime start; // セール開始日
-  final DateTime end; // セール終了日
-  final int stock; // 在庫数
-  final bool recommended; // おすすめフラグ
-  final bool lowest; // 最安値フラグ
-
-  SaleItem({
-    required this.name,
-    required this.shop,
-    required this.regularPrice,
-    required this.salePrice,
-    required this.start,
-    required this.end,
-    required this.stock,
-    this.recommended = false,
-    this.lowest = false,
-  });
-}
+import 'models/sale_item.dart';
+import 'util/localization_extensions.dart';
+import 'widgets/sale_item_card.dart';
 
 /// 買い得リスト画面
 class SaleListPage extends StatefulWidget {
@@ -160,78 +138,9 @@ class _SaleListPageState extends State<SaleListPage> {
               itemCount: sorted.length,
               itemBuilder: (context, index) {
                 final item = sorted[index];
-                final daysLeft = item.end.difference(DateTime.now()).inDays;
-                final expired = daysLeft <= 1;
-                final period =
-                    '${item.start.month}/${item.start.day}〜${item.end.month}/${item.end.day}';
-                return Dismissible(
-                  key: ValueKey(item.name + item.shop),
-                  background: Container(color: Colors.green),
-                  secondaryBackground: Container(color: Colors.red),
-                  onDismissed: (_) {},
-                  child: Card(
-                    margin: const EdgeInsets.only(bottom: 12),
-                    child: Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Row(
-                            children: [
-                              Expanded(
-                                child: Text(
-                                  item.name,
-                                  style: const TextStyle(
-                                    fontSize: 18,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                ),
-                              ),
-                              if (item.recommended)
-                                const Icon(Icons.notifications_active,
-                                    color: Colors.orange),
-                              if (item.lowest)
-                                const Icon(Icons.price_check, color: Colors.red),
-                            ],
-                          ),
-                          const SizedBox(height: 4),
-                          Text(item.shop),
-                          const SizedBox(height: 4),
-                          Text(
-                            '${loc.salePriceLabel(item.salePrice.toStringAsFixed(0))}  '
-                            '${loc.regularPriceLabel(item.regularPrice.toStringAsFixed(0))}',
-                          ),
-                          const SizedBox(height: 4),
-                          Text(loc.salePeriod(period)),
-                          const SizedBox(height: 4),
-                          Text(
-                            loc.daysLeft(daysLeft.toString()),
-                            style: TextStyle(color: expired ? Colors.red : null),
-                          ),
-                          const SizedBox(height: 4),
-                          Text(loc.stockInfo(item.stock)),
-                          const SizedBox(height: 8),
-                          Align(
-                            alignment: Alignment.centerRight,
-                            child: ElevatedButton(
-                              // 商品を買い物リストへ追加するボタン
-                              onPressed: () async {
-                                await _addBuyItem(BuyItem(item.name, ''));
-                                if (!mounted) return;
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  SnackBar(
-                                    content:
-                                        Text(AppLocalizations.of(context)!.addedBuyItem),
-                                  ),
-                                );
-                              },
-                              child: Text(loc.addToList()),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
+                return SaleItemCard(
+                  item: item,
+                  addUsecase: _addBuyItem,
                 );
               },
             ),
@@ -240,16 +149,4 @@ class _SaleListPageState extends State<SaleListPage> {
       ),
     );
   }
-}
-
-// この画面専用の簡易ローカライズ用拡張
-extension _LocExt on AppLocalizations {
-  String salePeriod(String period) => '期間: $period';
-  String stockInfo(int count) => '在庫 $count個';
-  String addToList() => '買い物リストに追加';
-  String saleListTitle() => '買い得リスト';
-  String saleNotify() => 'セール通知';
-  String sortEndDate() => '終了日が近い順';
-  String sortDiscount() => '割引率順';
-  String sortRecommend() => 'おすすめ順';
 }

--- a/lib/util/localization_extensions.dart
+++ b/lib/util/localization_extensions.dart
@@ -1,0 +1,21 @@
+import '../i18n/app_localizations.dart';
+
+/// セール情報画面専用のローカライズ拡張
+extension SaleLocExt on AppLocalizations {
+  /// セール期間表示用
+  String salePeriod(String period) => '期間: $period';
+  /// 在庫数表示用
+  String stockInfo(int count) => '在庫 $count個';
+  /// 買い物リスト追加ボタンのラベル
+  String addToList() => '買い物リストに追加';
+  /// セール画面タイトル
+  String saleListTitle() => '買い得リスト';
+  /// セール通知ラベル
+  String saleNotify() => 'セール通知';
+  /// 終了日順ソートラベル
+  String sortEndDate() => '終了日が近い順';
+  /// 割引率順ソートラベル
+  String sortDiscount() => '割引率順';
+  /// おすすめ順ソートラベル
+  String sortRecommend() => 'おすすめ順';
+}

--- a/lib/widgets/prediction_card.dart
+++ b/lib/widgets/prediction_card.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import '../domain/entities/buy_item.dart';
+import '../domain/entities/category.dart';
+import '../domain/entities/inventory.dart';
+import '../domain/repositories/inventory_repository.dart';
+import '../domain/usecases/add_buy_item.dart';
+import '../domain/usecases/remove_prediction_item.dart';
+import '../i18n/app_localizations.dart';
+import '../inventory_detail_page.dart';
+
+/// 買い物予報画面で使用するカードウィジェット
+/// 右スワイプで予報リストから削除できる
+class PredictionCard extends StatelessWidget {
+  /// 表示するアイテム
+  final BuyItem item;
+  /// カテゴリ一覧。詳細画面遷移に利用する
+  final List<Category> categories;
+  /// 在庫リポジトリ
+  final InventoryRepository repository;
+  /// 買い物リスト追加ユースケース
+  final AddBuyItem addUsecase;
+  /// 予報リスト削除ユースケース
+  final RemovePredictionItem removeUsecase;
+  /// 残り日数計算処理
+  final Future<int> Function(Inventory inv) calcDaysLeft;
+
+  const PredictionCard({
+    super.key,
+    required this.item,
+    required this.categories,
+    required this.repository,
+    required this.addUsecase,
+    required this.removeUsecase,
+    required this.calcDaysLeft,
+  });
+
+  /// 在庫詳細画面を開く
+  void _openDetail(BuildContext context) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => InventoryDetailPage(
+          inventoryId: item.inventoryId!,
+          categories: categories,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    return Dismissible(
+      key: ValueKey(item.key),
+      direction: DismissDirection.startToEnd,
+      onDismissed: (_) => removeUsecase(item),
+      background: Container(
+        color: Colors.red,
+        alignment: Alignment.centerLeft,
+        padding: const EdgeInsets.only(left: 16),
+        child: const Icon(Icons.delete, color: Colors.white),
+      ),
+      child: StreamBuilder<Inventory?>(
+        stream: repository.watchInventory(item.inventoryId!),
+        builder: (context, snapshot) {
+          final detailButton = IconButton(
+            icon: const Icon(Icons.info_outline),
+            onPressed: () => _openDetail(context),
+          );
+          if (!snapshot.hasData) {
+            return ListTile(title: Text(item.name), trailing: detailButton);
+          }
+          final inv = snapshot.data!;
+          return FutureBuilder<int>(
+            future: calcDaysLeft(inv),
+            builder: (context, daysSnapshot) {
+              final daysText = daysSnapshot.hasData
+                  ? ' ・ ${loc.daysLeft(daysSnapshot.data!.toString())}'
+                  : '';
+              final subtitle =
+                  '${inv.quantity.toStringAsFixed(1)}${inv.unit}$daysText';
+              return ListTile(
+                title: Text(item.name),
+                subtitle: Text(subtitle),
+                trailing: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    IconButton(
+                      icon: const Icon(Icons.playlist_add),
+                      onPressed: () async {
+                        await addUsecase(
+                            BuyItem(inv.itemName, inv.category, inv.id));
+                        await removeUsecase(item);
+                        if (context.mounted) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(content: Text(loc.addedBuyItem)),
+                          );
+                        }
+                      },
+                    ),
+                    detailButton,
+                  ],
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/widgets/sale_item_card.dart
+++ b/lib/widgets/sale_item_card.dart
@@ -1,0 +1,88 @@
+import "../i18n/app_localizations.dart";
+import 'package:flutter/material.dart';
+import '../domain/usecases/add_buy_item.dart';
+import '../domain/entities/buy_item.dart';
+import '../models/sale_item.dart';
+import '../util/localization_extensions.dart';
+
+/// セール情報画面で使用するカードウィジェット
+class SaleItemCard extends StatelessWidget {
+  /// 表示するセール情報
+  final SaleItem item;
+  /// 買い物リスト追加ユースケース
+  final AddBuyItem addUsecase;
+
+  const SaleItemCard({
+    super.key,
+    required this.item,
+    required this.addUsecase,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    final daysLeft = item.end.difference(DateTime.now()).inDays;
+    final expired = daysLeft <= 1;
+    final period =
+        '${item.start.month}/${item.start.day}〜${item.end.month}/${item.end.day}';
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    item.name,
+                    style: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                if (item.recommended)
+                  const Icon(Icons.notifications_active, color: Colors.orange),
+                if (item.lowest)
+                  const Icon(Icons.price_check, color: Colors.red),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(item.shop),
+            const SizedBox(height: 4),
+            Text(
+              '${loc.salePriceLabel(item.salePrice.toStringAsFixed(0))}  '
+              '${loc.regularPriceLabel(item.regularPrice.toStringAsFixed(0))}',
+            ),
+            const SizedBox(height: 4),
+            Text(loc.salePeriod(period)),
+            const SizedBox(height: 4),
+            Text(
+              loc.daysLeft(daysLeft.toString()),
+              style: TextStyle(color: expired ? Colors.red : null),
+            ),
+            const SizedBox(height: 4),
+            Text(loc.stockInfo(item.stock)),
+            const SizedBox(height: 8),
+            Align(
+              alignment: Alignment.centerRight,
+              child: ElevatedButton(
+                onPressed: () async {
+                  await addUsecase(BuyItem(item.name, ''));
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text(loc.addedBuyItem)),
+                    );
+                  }
+                },
+                child: Text(loc.addToList()),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/prediction_card_test.dart
+++ b/test/prediction_card_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oouchi_stock/widgets/prediction_card.dart';
+import 'package:oouchi_stock/domain/entities/buy_item.dart';
+import 'package:oouchi_stock/domain/entities/category.dart';
+import 'package:oouchi_stock/domain/entities/inventory.dart';
+import 'package:oouchi_stock/domain/entities/history_entry.dart';
+import 'package:oouchi_stock/domain/repositories/inventory_repository.dart';
+import 'package:oouchi_stock/domain/repositories/buy_list_repository.dart';
+import 'package:oouchi_stock/domain/repositories/buy_prediction_repository.dart';
+import 'package:oouchi_stock/domain/usecases/add_buy_item.dart';
+import 'package:oouchi_stock/domain/usecases/remove_prediction_item.dart';
+
+class _FakeInventoryRepository implements InventoryRepository {
+  @override
+  Stream<Inventory?> watchInventory(String inventoryId) => Stream.value(Inventory(
+        id: 'inv1',
+        itemName: 'テスト',
+        category: '日用品',
+        itemType: '一般',
+        quantity: 1.0,
+        unit: '個',
+        monthlyConsumption: 0,
+        createdAt: DateTime.now(),
+      ));
+
+  // 以下のメソッドはテストでは使用しない
+  @override
+  Future<List<Inventory>> fetchAll() async => [];
+  @override
+  Future<String> addInventory(Inventory inventory) async => '';
+  @override
+  Future<void> updateQuantity(String id, double amount, String type) async {}
+  @override
+  Future<void> updateInventory(Inventory inventory) async {}
+  @override
+  Future<void> stocktake(String id, double before, double after, double diff) async {}
+  @override
+  Future<void> deleteInventory(String id) async {}
+  @override
+  Stream<List<Inventory>> watchByCategory(String category) => const Stream.empty();
+  @override
+  Stream<List<Inventory>> watchNeedsBuy(double threshold) => const Stream.empty();
+  @override
+  Stream<List<HistoryEntry>> watchHistory(String inventoryId) => const Stream.empty();
+}
+
+class _DummyBuyListRepo implements BuyListRepository {
+  @override
+  Stream<List<BuyItem>> watchItems() => const Stream.empty();
+  @override
+  Future<void> addItem(BuyItem item) async {}
+  @override
+  Future<void> removeItem(BuyItem item) async {}
+}
+
+class _DummyPredictionRepo implements BuyPredictionRepository {
+  @override
+  Stream<List<BuyItem>> watchItems() => const Stream.empty();
+  @override
+  Future<void> addItem(BuyItem item) async {}
+  @override
+  Future<void> removeItem(BuyItem item) async {}
+}
+
+void main() {
+  testWidgets('PredictionCard 表示テスト', (WidgetTester tester) async {
+    final item = BuyItem('テスト', '日用品', 'inv1');
+    final categories = [Category(id: 1, name: '日用品', createdAt: DateTime.now())];
+    await tester.pumpWidget(MaterialApp(
+      home: PredictionCard(
+        item: item,
+        categories: categories,
+        repository: _FakeInventoryRepository(),
+        addUsecase: AddBuyItem(_DummyBuyListRepo()),
+        removeUsecase: RemovePredictionItem(_DummyPredictionRepo()),
+        calcDaysLeft: (_) async => 7,
+      ),
+    ));
+    await tester.pump();
+    expect(find.text('テスト'), findsOneWidget);
+  });
+}

--- a/test/sale_list_page_test.dart
+++ b/test/sale_list_page_test.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:oouchi_stock/sale_list_page.dart';
+import 'package:oouchi_stock/widgets/sale_item_card.dart';
 
 void main() {
   testWidgets('SaleListPage 初期表示', (WidgetTester tester) async {
     await tester.pumpWidget(const MaterialApp(home: SaleListPage()));
     expect(find.byType(AppBar), findsOneWidget);
-    expect(find.byType(Card), findsWidgets);
+    expect(find.byType(SaleItemCard), findsWidgets);
   });
 }


### PR DESCRIPTION
## Summary
- 予報カードとセールカードを別ファイルへ切り出し
- HomePage と SaleListPage を新カードで表示
- テストを更新し新ウィジェットを検証
- アーキテクチャ提案書にカード分割の説明を追記

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856bf2c46f0832e806d9f5d47137735