### PR TITLE
Fix prediction card style

### DIFF
--- a/lib/widgets/prediction_card.dart
+++ b/lib/widgets/prediction_card.dart
@@ -67,8 +67,12 @@ class PredictionCard extends StatelessWidget {
             icon: const Icon(Icons.info_outline),
             onPressed: () => _openDetail(context),
           );
+          // 在庫がまだ取得できない場合もカードとして表示する
           if (!snapshot.hasData) {
-            return ListTile(title: Text(item.name), trailing: detailButton);
+            return Card(
+              margin: const EdgeInsets.only(bottom: 12),
+              child: ListTile(title: Text(item.name), trailing: detailButton),
+            );
           }
           final inv = snapshot.data!;
           return FutureBuilder<int>(
@@ -79,27 +83,31 @@ class PredictionCard extends StatelessWidget {
                   : '';
               final subtitle =
                   '${inv.quantity.toStringAsFixed(1)}${inv.unit}$daysText';
-              return ListTile(
-                title: Text(item.name),
-                subtitle: Text(subtitle),
-                trailing: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    IconButton(
-                      icon: const Icon(Icons.playlist_add),
-                      onPressed: () async {
-                        await addUsecase(
-                            BuyItem(inv.itemName, inv.category, inv.id));
-                        await removeUsecase(item);
-                        if (context.mounted) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(content: Text(loc.addedBuyItem)),
-                          );
-                        }
-                      },
-                    ),
-                    detailButton,
-                  ],
+              return Card(
+                // 買い物予報画面の1アイテムをカード表示
+                margin: const EdgeInsets.only(bottom: 12),
+                child: ListTile(
+                  title: Text(item.name),
+                  subtitle: Text(subtitle),
+                  trailing: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      IconButton(
+                        icon: const Icon(Icons.playlist_add),
+                        onPressed: () async {
+                          await addUsecase(
+                              BuyItem(inv.itemName, inv.category, inv.id));
+                          await removeUsecase(item);
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(content: Text(loc.addedBuyItem)),
+                            );
+                          }
+                        },
+                      ),
+                      detailButton,
+                    ],
+                  ),
                 ),
               );
             },

--- a/test/prediction_card_test.dart
+++ b/test/prediction_card_test.dart
@@ -79,5 +79,7 @@ void main() {
     ));
     await tester.pump();
     expect(find.text('テスト'), findsOneWidget);
+    // カードウィジェットとして表示されることを確認
+    expect(find.byType(Card), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- fix prediction card design to show card borders like inventory page
- update prediction card widget test to expect a Card widget

## Testing
- `flutter test` *(fails: flutter command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68594687877c832eb626b8eb3dba41fe