### PR TITLE
Fix BuyListConditionType reference

### DIFF
--- a/test/buy_list_condition_settings_page_test.dart
+++ b/test/buy_list_condition_settings_page_test.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:oouchi_stock/buy_list_condition_settings_page.dart';
+import 'package:oouchi_stock/domain/entities/buy_list_condition_settings.dart';
+
+// 買い物予報条件設定画面のウィジェットテスト
 
 void main() {
   testWidgets('BuyListConditionSettingsPage 表示', (tester) async {


### PR DESCRIPTION
## Summary
- テストで `BuyListConditionType` を利用できるようにインポートを追加
- テストファイル先頭に画面説明コメントを追加

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68595bedc0cc832e864f8aab2632e410