### PR TITLE
Fix expiry parameter missing in search_filter_test

### DIFF
--- a/test/search_filter_test.dart
+++ b/test/search_filter_test.dart
@@ -32,6 +32,7 @@ void main() {
   });
 
   test('PriceCategoryList の検索条件', () {
+    // セール情報管理画面のリスト検索で利用するデータ
     final p1 = PriceInfo(
       id: '1',
       inventoryId: '1',
@@ -49,6 +50,7 @@ void main() {
       approvalUrl: '',
       memo: '',
       unitPrice: 100,
+      expiry: DateTime.now().add(const Duration(days: 1)),
     );
     final p2 = PriceInfo(
       id: '2',
@@ -67,6 +69,7 @@ void main() {
       approvalUrl: '',
       memo: '',
       unitPrice: 50,
+      expiry: DateTime.now().add(const Duration(days: 1)),
     );
     final list = [p1, p2];
     const keyword = '野菜';


### PR DESCRIPTION
## Summary
- search_filter_testのPriceInfoに期限(expiry)を追加

## Testing
- `flutter test test/search_filter_test.dart -r json` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_68595c300078832ea14abff8523f935d