### PR TITLE
Fix HistoryEntry construction in inventory detail test

### DIFF
--- a/test/inventory_detail_page_test.dart
+++ b/test/inventory_detail_page_test.dart
@@ -56,13 +56,15 @@ class _DataRepository extends _FakeRepository {
   @override
   Stream<List<HistoryEntry>> watchHistory(String inventoryId) =>
       Stream.value([
+        // 履歴エントリを生成
         HistoryEntry(
-            timestamp: DateTime.now(),
-            type: 'add',
-            quantity: 1,
-            before: 0,
-            after: 1,
-            diff: 1),
+          'add',
+          1,
+          DateTime.now(),
+          before: 0,
+          after: 1,
+          diff: 1,
+        ),
       ]);
 }
 


### PR DESCRIPTION
## Summary
- testでHistoryEntryを生成する際、名前付き引数を使っていたためエラーが発生していた
- 位置引数に修正しテストを更新

## Testing
- `flutter test test/inventory_detail_page_test.dart` *(fails: flutter command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68595c0e57d4832e97a9fe0ad64344fa