### PR TITLE
Add viewmodel for buy list page

### DIFF
--- a/docs/architecture_proposals_ja.md
+++ b/docs/architecture_proposals_ja.md
@@ -22,6 +22,9 @@
 - ViewModel が UseCase を呼び出し、画面は ViewModel を監視するだけにすると見通しが良くなります。
 - 例として `AddInventoryPage` をはじめ、カテゴリの追加・編集画面やセール情報追加画面も
   ViewModel (`AddCategoryViewModel`, `EditCategoryViewModel`, `EditInventoryViewModel` など) で状態管理するようリファクタリングしました。
+  さらに在庫一覧画面でも `InventoryPageViewModel` と `InventoryListViewModel` を導入し、
+  画面の状態遷移を ViewModel に集約しました。
+  買い物予報画面も `BuyListViewModel` を用いてロジックを分離しています。
 
 ## 4. ルーティングの整理
 - 画面遷移が複雑になった場合は、Navigator 2.0 (Router API) を利用してルーティングを一元管理します。

--- a/lib/presentation/viewmodels/buy_list_viewmodel.dart
+++ b/lib/presentation/viewmodels/buy_list_viewmodel.dart
@@ -1,0 +1,115 @@
+import 'dart:async';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+import '../../domain/entities/buy_item.dart';
+import '../../domain/entities/buy_list_condition_settings.dart';
+import '../../domain/entities/category.dart';
+import '../../domain/entities/category_order.dart';
+import '../../domain/entities/inventory.dart';
+import '../../domain/repositories/inventory_repository.dart';
+import '../../domain/services/buy_list_strategy.dart';
+import '../../domain/usecases/add_buy_item.dart';
+import '../../domain/usecases/remove_buy_item.dart';
+import '../../domain/usecases/watch_buy_items.dart';
+import '../../util/date_time_parser.dart';
+import '../../util/firestore_refs.dart';
+
+/// 買い物予報画面の状態を管理する ViewModel
+/// カテゴリ読み込みや条件設定、リスト操作を担当する
+class BuyListViewModel extends ChangeNotifier {
+  /// 在庫リポジトリ
+  final InventoryRepository repository;
+  /// 買い物リスト追加ユースケース
+  final AddBuyItem addUsecase;
+  /// 買い物リスト削除ユースケース
+  final RemoveBuyItem removeUsecase;
+  /// 買い物リスト監視ユースケース
+  final WatchBuyItems watchUsecase;
+
+  /// 追加テキスト入力用コントローラ
+  final TextEditingController itemController = TextEditingController();
+
+  /// カテゴリ一覧
+  List<Category> categories = [];
+  /// 読み込み済みかどうか
+  bool loaded = false;
+  /// 条件設定
+  BuyListConditionSettings? condition;
+
+  StreamSubscription<List<Inventory>>? _invSub;
+
+  BuyListViewModel({
+    required this.repository,
+    required this.addUsecase,
+    required this.removeUsecase,
+    required this.watchUsecase,
+  });
+
+  /// 買い物リストストリーム
+  Stream<List<BuyItem>> get stream => watchUsecase();
+
+  /// 初期データを読み込む
+  Future<void> load({List<Category>? initialCategories}) async {
+    await _invSub?.cancel();
+    if (initialCategories != null && initialCategories.isNotEmpty) {
+      categories = await applyCategoryOrder(List<Category>.from(initialCategories));
+    } else {
+      final snapshot = await userCollection('categories')
+          .orderBy('createdAt')
+          .get();
+      categories = snapshot.docs.map((d) {
+        final data = d.data();
+        return Category(
+          id: data['id'] ?? 0,
+          name: data['name'] ?? '',
+          createdAt: parseDateTime(data['createdAt']),
+          color: data['color'],
+        );
+      }).toList();
+      categories = await applyCategoryOrder(categories);
+    }
+    condition = await loadBuyListConditionSettings();
+    loaded = true;
+    notifyListeners();
+    final strategy = createStrategy(condition!);
+    _invSub = strategy.watch(repository).listen((list) {
+      for (final inv in list) {
+        addUsecase(BuyItem(inv.itemName, inv.category, inv.id));
+      }
+    });
+  }
+
+  /// カテゴリ更新処理
+  void updateCategories(List<Category> list) {
+    categories = List<Category>.from(list);
+    notifyListeners();
+  }
+
+  /// 再読み込み処理
+  Future<void> refresh() async {
+    loaded = false;
+    notifyListeners();
+    await load();
+  }
+
+  /// 手動追加処理
+  Future<void> addManualItem() async {
+    final text = itemController.text.trim();
+    if (text.isEmpty) return;
+    await addUsecase(BuyItem(text, ''));
+    itemController.clear();
+  }
+
+  /// アイテム削除処理
+  Future<void> removeItem(BuyItem item) async {
+    await removeUsecase(item);
+  }
+
+  @override
+  void dispose() {
+    _invSub?.cancel();
+    itemController.dispose();
+    super.dispose();
+  }
+}

--- a/lib/presentation/viewmodels/inventory_list_viewmodel.dart
+++ b/lib/presentation/viewmodels/inventory_list_viewmodel.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/entities/inventory.dart';
+import '../../domain/entities/category.dart';
+import '../../domain/entities/buy_item.dart';
+import '../../domain/usecases/watch_inventories.dart';
+import '../../domain/usecases/delete_inventory.dart';
+import '../../domain/usecases/add_buy_item.dart';
+
+/// 在庫一覧の1タブ分の状態を管理する ViewModel
+/// 検索ワードや並び替え条件を保持し、在庫データのストリームを提供する
+class InventoryListViewModel extends ChangeNotifier {
+  /// 表示対象カテゴリ名
+  final String category;
+  final WatchInventories watchUsecase;
+  final DeleteInventory deleteUsecase;
+  final AddBuyItem addUsecase;
+
+  /// 検索文字列
+  String search = '';
+
+  /// 並び替え条件 ('alphabet' または 'updated')
+  String sort = 'updated';
+
+  /// 検索バーのコントローラ
+  final TextEditingController controller = TextEditingController();
+
+  InventoryListViewModel({
+    required this.category,
+    required this.watchUsecase,
+    required this.deleteUsecase,
+    required this.addUsecase,
+  });
+
+  /// 在庫ストリームを取得
+  Stream<List<Inventory>> get stream => watchUsecase(category);
+
+  /// 検索文字列を更新
+  void setSearch(String value) {
+    search = value;
+    notifyListeners();
+  }
+
+  /// 並び替え条件を更新
+  void setSort(String value) {
+    sort = value;
+    notifyListeners();
+  }
+
+  /// 在庫を買い物リストへ追加
+  Future<void> addToBuyList(Inventory inv) async {
+    await addUsecase(BuyItem(inv.itemName, inv.category, inv.id));
+  }
+
+  /// 在庫を削除
+  Future<void> delete(String id) async {
+    await deleteUsecase(id);
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+}

--- a/lib/presentation/viewmodels/inventory_page_viewmodel.dart
+++ b/lib/presentation/viewmodels/inventory_page_viewmodel.dart
@@ -1,0 +1,69 @@
+import 'dart:async';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+import '../../domain/entities/category.dart';
+import '../../domain/entities/category_order.dart';
+import '../../util/firestore_refs.dart';
+import '../../util/date_time_parser.dart';
+
+/// 在庫一覧画面全体の状態を管理する ViewModel
+/// カテゴリの読み込みと更新処理を担当する
+class InventoryPageViewModel extends ChangeNotifier {
+  /// Firestore から取得したカテゴリ一覧
+  List<Category> categories = [];
+
+  /// カテゴリが読み込み済みかどうか
+  bool categoriesLoaded = false;
+
+  StreamSubscription<QuerySnapshot<Map<String, dynamic>>>? _catSub;
+
+  /// 初期カテゴリを読み込み、Firestore 監視を開始する
+  Future<void> loadCategories(List<Category>? initial) async {
+    if (initial != null && initial.isNotEmpty) {
+      categories = List<Category>.from(initial);
+      categories = await applyCategoryOrder(categories);
+      categoriesLoaded = true;
+      notifyListeners();
+    } else {
+      _catSub = userCollection('categories')
+          .orderBy('createdAt')
+          .snapshots()
+          .listen((snapshot) async {
+        var list = snapshot.docs.map((d) {
+          final data = d.data();
+          return Category(
+            id: data['id'] ?? 0,
+            name: data['name'] ?? '',
+            createdAt: parseDateTime(data['createdAt']),
+            color: data['color'],
+          );
+        }).toList();
+        list = await applyCategoryOrder(list);
+        categories = list;
+        categoriesLoaded = true;
+        notifyListeners();
+      });
+    }
+  }
+
+  /// 設定画面から戻った際などにカテゴリリストを更新する
+  void updateCategories(List<Category> list) {
+    categories = List<Category>.from(list);
+    categoriesLoaded = true;
+    notifyListeners();
+  }
+
+  /// カテゴリ情報を再読み込みする
+  Future<void> refresh() async {
+    await _catSub?.cancel();
+    categoriesLoaded = false;
+    await loadCategories(null);
+  }
+
+  @override
+  void dispose() {
+    _catSub?.cancel();
+    super.dispose();
+  }
+}


### PR DESCRIPTION
## Summary
- BuyListPage を BuyListViewModel により状態管理するようリファクタリング
- BuyListViewModel を新規追加
- アーキテクチャ説明書を更新

## Testing
- `flutter test` 実行 (Flutter 未インストールのため失敗)


------
https://chatgpt.com/codex/tasks/task_e_685aab70c0d4832ea74211d838fc2b8b