### PR TITLE
ViewModel 分離

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -1,33 +1,18 @@
-import 'dart:async';
 import 'package:flutter/material.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
-import 'util/firestore_refs.dart';
-import 'util/date_time_parser.dart';
 import 'package:oouchi_stock/i18n/app_localizations.dart';
 import 'add_category_page.dart';
+import "domain/entities/category.dart";
+import "domain/entities/buy_item.dart";
 import 'widgets/settings_menu_button.dart';
-// 在庫カードウィジェット
 import 'widgets/inventory_card.dart';
 import 'widgets/prediction_card.dart';
-// 在庫詳細画面
 import 'inventory_detail_page.dart';
 import 'main.dart';
 import 'data/repositories/inventory_repository_impl.dart';
-import 'domain/entities/category.dart';
-import 'domain/entities/inventory.dart';
-import 'domain/entities/category_order.dart';
-import 'domain/usecases/calculate_days_left.dart';
-import 'domain/entities/buy_list_condition_settings.dart';
-import 'data/repositories/buy_list_repository_impl.dart';
-import 'domain/entities/buy_item.dart';
-import 'domain/usecases/add_buy_item.dart';
-import 'data/repositories/buy_prediction_repository_impl.dart';
-import 'domain/usecases/watch_prediction_items.dart';
-import 'domain/usecases/remove_prediction_item.dart';
+import 'presentation/viewmodels/home_page_viewmodel.dart';
 
 /// ホーム画面。起動時に表示され、買い物リストを管理する。
 class HomePage extends StatefulWidget {
-  /// 起動時に受け取るカテゴリ一覧。null の場合は Firestore から取得する
   final List<Category>? categories;
   const HomePage({super.key, this.categories});
 
@@ -36,118 +21,42 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
-  /// Firestore から取得したカテゴリ一覧
-  List<Category> _categories = [];
-  /// カテゴリが読み込み済みかどうかのフラグ
-  bool _categoriesLoaded = false;
-  /// カテゴリコレクションを監視するストリーム購読
-  StreamSubscription<QuerySnapshot<Map<String, dynamic>>>? _catSub;
-  /// 買い物予報の条件設定
-  BuyListConditionSettings? _conditionSettings;
-
-  /// 在庫の残り日数計算用ユースケース
-  final CalculateDaysLeft _calcUsecase =
-      CalculateDaysLeft(InventoryRepositoryImpl());
-
-
-  // 買い物リストへ商品を追加するユースケース
-  final AddBuyItem _addBuyItem = AddBuyItem(BuyListRepositoryImpl());
-
-  // 予報リストの監視・操作用
-  final _predictionRepo = BuyPredictionRepositoryImpl();
-  late final WatchPredictionItems _watchPrediction =
-      WatchPredictionItems(_predictionRepo);
-  late final RemovePredictionItem _removePrediction =
-      RemovePredictionItem(_predictionRepo);
-
-  /// 設定画面から戻った際にカテゴリリストを更新する
-  void _updateCategories(List<Category> list) {
-    setState(() {
-      _categories = List.from(list);
-      _categoriesLoaded = true;
-    });
-  }
-
-  Future<void> _loadCondition() async {
-    // 設定画面から戻った際にも呼ばれ、買い物予報条件を再読み込みする
-    final s = await loadBuyListConditionSettings();
-    setState(() => _conditionSettings = s);
-  }
-
-  /// ホーム画面の在庫カード表示時に履歴から残り日数を計算する
-  Future<int> _calcDaysLeft(Inventory inv) async {
-    // インベントリカード描画時に呼び出される
-    // 新設したユースケースに処理を委譲する
-    return _calcUsecase(inv);
-  }
+  late final HomePageViewModel _viewModel;
 
   @override
   void initState() {
     super.initState();
-    _loadCondition();
-    // 引数でカテゴリが渡され、1件以上存在する場合のみ利用する
-    if (widget.categories != null && widget.categories!.isNotEmpty) {
-      _categories = List.from(widget.categories!);
-      applyCategoryOrder(_categories).then((list) {
-        setState(() {
-          _categories = list;
-          _categoriesLoaded = true;
-        });
-      });
-    } else {
-      // カテゴリが空の場合は Firestore を監視して更新を待つ
-      // Firestore からカテゴリ一覧を取得して監視
-      // カテゴリに変更があったときに実行される
-      _catSub = userCollection('categories')
-          .orderBy('createdAt')
-          .snapshots()
-          .listen((snapshot) async {
-        var list = snapshot.docs.map((d) {
-          final data = d.data();
-          return Category(
-            id: data['id'] ?? 0,
-            name: data['name'] ?? '',
-            createdAt: parseDateTime(data['createdAt']),
-          );
-        }).toList();
-        list = await applyCategoryOrder(list);
-        setState(() {
-          _categories = list;
-          _categoriesLoaded = true;
-        });
-      });
-    }
+    _viewModel = HomePageViewModel();
+    _viewModel.addListener(() { if (mounted) setState(() {}); });
+    _viewModel.loadCondition();
+    _viewModel.loadCategories(widget.categories);
   }
 
   @override
   void dispose() {
-    _catSub?.cancel();
+    _viewModel.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    // 画面描画。カテゴリが読み込まれるまではローディングを表示
-    if (!_categoriesLoaded) {
+    if (!_viewModel.categoriesLoaded) {
       return Scaffold(
         appBar: AppBar(title: Text(AppLocalizations.of(context)!.buyListTitle)),
         body: const Center(child: CircularProgressIndicator()),
       );
     }
-    // カテゴリがまだ存在しない場合は案内テキストと追加ボタンを表示
-    if (_categories.isEmpty) {
+    if (_viewModel.categories.isEmpty) {
       return Scaffold(
         appBar: AppBar(title: Text(AppLocalizations.of(context)!.buyListTitle)),
         body: Center(
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              // カテゴリ未登録メッセージ
               Text(AppLocalizations.of(context)!.noCategories),
               const SizedBox(height: 8),
               ElevatedButton(
                 onPressed: () {
-                  // カテゴリ追加画面へ遷移
                   Navigator.push(
                     context,
                     MaterialPageRoute(builder: (_) => const AddCategoryPage()),
@@ -160,16 +69,11 @@ class _HomePageState extends State<HomePage> {
         ),
       );
     }
-
-    // 買い物予報条件が未読込の場合はローディングを表示
-    // 設定変更後の復帰直後などに発生する
-    if (_conditionSettings == null) {
+    if (_viewModel.conditionSettings == null) {
       return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
-    // 画面表示時に在庫一覧を取得
-    // 画面描画時に在庫一覧を取得する
-    return StreamBuilder<List<BuyItem>>( 
-      stream: _watchPrediction(),
+    return StreamBuilder<List<BuyItem>>(
+      stream: _viewModel.watchPrediction(),
       builder: (context, snapshot) {
         if (!snapshot.hasData) {
           return const Scaffold(body: Center(child: CircularProgressIndicator()));
@@ -181,27 +85,27 @@ class _HomePageState extends State<HomePage> {
             body: Center(child: Text(AppLocalizations.of(context)!.noBuyItems)),
           );
         }
-        final map = {for (final c in _categories) c.name: <BuyItem>[]};
+        final map = {for (final c in _viewModel.categories) c.name: <BuyItem>[]};
         for (final item in items) {
           map[item.category]?.add(item);
         }
         return DefaultTabController(
-          length: _categories.length,
+          length: _viewModel.categories.length,
           child: Scaffold(
             appBar: AppBar(
               title: Text(AppLocalizations.of(context)!.buyListTitle),
               actions: [
                 SettingsMenuButton(
-                  categories: _categories,
-                  onCategoriesChanged: _updateCategories,
+                  categories: _viewModel.categories,
+                  onCategoriesChanged: _viewModel.updateCategories,
                   onLocaleChanged: (l) => context.findAncestorStateOfType<MyAppState>()?.updateLocale(l),
-                  onConditionChanged: _loadCondition,
+                  onConditionChanged: _viewModel.loadCondition,
                 )
               ],
               bottom: TabBar(
                 isScrollable: true,
                 tabs: [
-                  for (final c in _categories)
+                  for (final c in _viewModel.categories)
                     SizedBox(
                       width: MediaQuery.of(context).size.width / 3,
                       child: Tab(text: c.name),
@@ -211,7 +115,7 @@ class _HomePageState extends State<HomePage> {
             ),
             body: TabBarView(
               children: [
-                for (final c in _categories)
+                for (final c in _viewModel.categories)
                   map[c.name]!.isEmpty
                       ? Center(child: Text(AppLocalizations.of(context)!.noBuyItems))
                       : ListView(
@@ -220,11 +124,11 @@ class _HomePageState extends State<HomePage> {
                             for (final item in map[c.name]!)
                               PredictionCard(
                                 item: item,
-                                categories: _categories,
+                                categories: _viewModel.categories,
                                 repository: InventoryRepositoryImpl(),
-                                addUsecase: _addBuyItem,
-                                removeUsecase: _removePrediction,
-                                calcDaysLeft: _calcDaysLeft,
+                                addUsecase: _viewModel.addBuyItem,
+                                removeUsecase: _viewModel.removePrediction,
+                                calcDaysLeft: _viewModel.calcDaysLeft,
                               ),
                           ],
                         ),
@@ -235,5 +139,4 @@ class _HomePageState extends State<HomePage> {
       },
     );
   }
-
 }

--- a/lib/inventory_detail_page.dart
+++ b/lib/inventory_detail_page.dart
@@ -1,65 +1,42 @@
 import 'package:flutter/material.dart';
 import 'package:oouchi_stock/i18n/app_localizations.dart';
 import 'package:intl/intl.dart';
-import 'data/repositories/inventory_repository_impl.dart';
-import 'domain/repositories/inventory_repository.dart';
-import 'domain/entities/history_entry.dart';
-import 'domain/entities/inventory.dart';
+import 'presentation/viewmodels/inventory_detail_viewmodel.dart';
 import 'domain/entities/category.dart';
 import 'edit_inventory_page.dart';
 
-
-// 商品詳細画面。履歴と予測日を表示する
+import "domain/entities/history_entry.dart";
+import "domain/entities/inventory.dart";
+import "domain/repositories/inventory_repository.dart";
+/// 商品詳細画面。履歴と予測日を表示する
 class InventoryDetailPage extends StatelessWidget {
-  /// 表示対象の在庫ID
-  final String inventoryId;
-  /// カテゴリ一覧
+  final InventoryDetailViewModel viewModel;
   final List<Category> categories;
-  /// 在庫リポジトリ
-  final InventoryRepository repository;
-
   InventoryDetailPage({
     super.key,
-    required this.inventoryId,
+    required String inventoryId,
     required this.categories,
     InventoryRepository? repository,
-  }) : repository = repository ?? InventoryRepositoryImpl();
-
-  /// 指定IDの在庫を監視するストリームを返す
-  Stream<Inventory?> inventoryStream() {
-    return repository.watchInventory(inventoryId);
-  }
-
-  /// 在庫履歴を監視するストリームを返す
-  Stream<List<HistoryEntry>> historyStream() {
-    return repository.watchHistory(inventoryId);
-  }
+  }) : viewModel = InventoryDetailViewModel(inventoryId: inventoryId, repository: repository);
 
   @override
   Widget build(BuildContext context) {
     return StreamBuilder<Inventory?>(
-      stream: inventoryStream(),
+      stream: viewModel.inventoryStream(),
       builder: (context, invSnapshot) {
         if (invSnapshot.hasError) {
           final err = invSnapshot.error?.toString() ?? 'unknown';
-          return Scaffold(
-            body: Center(child: Text(AppLocalizations.of(context)!.loadError(err))),
-          );
+          return Scaffold(body: Center(child: Text(AppLocalizations.of(context)!.loadError(err))));
         }
         if (!invSnapshot.hasData) {
-          return const Scaffold(
-            body: Center(child: CircularProgressIndicator()),
-          );
+          return const Scaffold(body: Center(child: CircularProgressIndicator()));
         }
         final inv = invSnapshot.data;
         if (inv == null) {
-          return Scaffold(
-            body: Center(child: Text(AppLocalizations.of(context)!.loadError('not found'))),
-          );
+          return Scaffold(body: Center(child: Text(AppLocalizations.of(context)!.loadError('not found'))));
         }
         return Scaffold(
           appBar: AppBar(title: Text(inv.itemName), actions: [
-            // 編集ボタン。押すと編集画面へ遷移する
             IconButton(
               icon: const Icon(Icons.edit),
               onPressed: () {
@@ -67,16 +44,11 @@ class InventoryDetailPage extends StatelessWidget {
                   context,
                   MaterialPageRoute(
                     builder: (_) => EditInventoryPage(
-                      id: inventoryId,
+                      id: viewModel.inventoryId,
                       itemName: inv.itemName,
                       category: categories.firstWhere(
                         (e) => e.name == inv.category,
-                        orElse: () => Category(
-                          id: 0,
-                          name: inv.category,
-                          createdAt: DateTime.now(),
-                          color: null,
-                        ),
+                        orElse: () => Category(id: 0, name: inv.category, createdAt: DateTime.now(), color: null),
                       ),
                       itemType: inv.itemType,
                       unit: inv.unit,
@@ -88,7 +60,7 @@ class InventoryDetailPage extends StatelessWidget {
             )
           ]),
           body: StreamBuilder<List<HistoryEntry>>(
-            stream: historyStream(),
+            stream: viewModel.historyStream(),
             builder: (context, snapshot) {
               if (!snapshot.hasData) {
                 return const Center(child: CircularProgressIndicator());
@@ -98,52 +70,25 @@ class InventoryDetailPage extends StatelessWidget {
               if (inv.monthlyConsumption <= 0) {
                 predicted = DateTime.now();
               } else {
-                final days =
-                    (inv.quantity / inv.monthlyConsumption * 30).ceil();
+                final days = (inv.quantity / inv.monthlyConsumption * 30).ceil();
                 predicted = DateTime.now().add(Duration(days: days));
               }
-              final textStyle = Theme.of(context)
-                  .textTheme
-                  .bodyLarge
-                  ?.copyWith(fontSize: 18);
-
+              final textStyle = Theme.of(context).textTheme.bodyLarge?.copyWith(fontSize: 18);
               return ListView(
                 padding: const EdgeInsets.all(16),
                 children: [
-                  _buildDetailRow(
-                    AppLocalizations.of(context)!.category,
-                    inv.category,
-                    textStyle,
-                  ),
-                  _buildDetailRow(
-                    AppLocalizations.of(context)!.itemType,
-                    inv.itemType,
-                    textStyle,
-                  ),
-                  _buildDetailRow(
-                    AppLocalizations.of(context)!.quantity,
-                    '${inv.quantity.toStringAsFixed(1)}${inv.unit}',
-                    textStyle,
-                  ),
-                  _buildDetailRow(
-                    AppLocalizations.of(context)!.monthlyConsumption,
-                    inv.monthlyConsumption.toStringAsFixed(1),
-                    textStyle,
-                  ),
+                  _buildDetailRow(AppLocalizations.of(context)!.category, inv.category, textStyle),
+                  _buildDetailRow(AppLocalizations.of(context)!.itemType, inv.itemType, textStyle),
+                  _buildDetailRow(AppLocalizations.of(context)!.quantity, '${inv.quantity.toStringAsFixed(1)}${inv.unit}', textStyle),
+                  _buildDetailRow(AppLocalizations.of(context)!.monthlyConsumption, inv.monthlyConsumption.toStringAsFixed(1), textStyle),
                   const SizedBox(height: 8),
-                  _buildDetailRow(
-                    AppLocalizations.of(context)!.predictLabel,
-                    _formatDate(predicted),
-                    textStyle,
-                  ),
+                  _buildDetailRow(AppLocalizations.of(context)!.predictLabel, _formatDate(predicted), textStyle),
                   const SizedBox(height: 16),
-                  Text(AppLocalizations.of(context)!.history,
-                      style: const TextStyle(fontSize: 18)),
+                  Text(AppLocalizations.of(context)!.history, style: const TextStyle(fontSize: 18)),
                   SizedBox(
                     height: MediaQuery.of(context).size.height / 3,
                     child: ListView(
-                      children:
-                          list.map((e) => _buildHistoryTile(e, inv.unit)).toList(),
+                      children: list.map((e) => _buildHistoryTile(e, inv.unit)).toList(),
                     ),
                   ),
                 ],
@@ -155,8 +100,6 @@ class InventoryDetailPage extends StatelessWidget {
     );
   }
 
-
-  /// 項目名と値を左右に表示する行を生成
   Widget _buildDetailRow(String label, String value, TextStyle? style) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),
@@ -165,31 +108,21 @@ class InventoryDetailPage extends StatelessWidget {
         children: [
           Expanded(child: Text(label, style: style)),
           const SizedBox(width: 8),
-          Expanded(
-            child: Text(
-              value,
-              style: style,
-              textAlign: TextAlign.right,
-            ),
-          ),
+          Expanded(child: Text(value, style: style, textAlign: TextAlign.right)),
         ],
       ),
     );
   }
 
-  // 日付を "yyyy/MM/dd HH:mm" 形式で返す
   String _formatDate(DateTime date) {
     return DateFormat('yyyy/MM/dd HH:mm').format(date);
   }
 
-  /// 履歴表示用のタイルを作成する。
   Widget _buildHistoryTile(HistoryEntry e, String unit) {
     final diffSign = e.diff >= 0 ? '+' : '-';
-    final quantityText =
-        '${e.before.toStringAsFixed(1)} -> ${e.after.toStringAsFixed(1)} ($diffSign${e.diff.abs().toStringAsFixed(1)}$unit)';
+    final quantityText = '${e.before.toStringAsFixed(1)} -> ${e.after.toStringAsFixed(1)} ($diffSign${e.diff.abs().toStringAsFixed(1)}$unit)';
     final color = e.diff >= 0 ? Colors.green : Colors.red;
     final style = const TextStyle(fontSize: 18);
-
     return Column(
       children: [
         Row(
@@ -210,7 +143,6 @@ class InventoryDetailPage extends StatelessWidget {
     );
   }
 
-  /// 操作種別を日本語で返す
   String _typeLabel(String type) {
     switch (type) {
       case 'stocktake':

--- a/lib/item_type_settings_page.dart
+++ b/lib/item_type_settings_page.dart
@@ -1,19 +1,14 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
-import 'util/firestore_refs.dart';
-import 'util/date_time_parser.dart';
-
+import 'presentation/viewmodels/item_type_settings_viewmodel.dart';
 import 'domain/entities/item_type.dart';
 import 'domain/entities/category.dart';
 import 'add_item_type_page.dart';
 import 'edit_item_type_page.dart';
-import 'default_item_types.dart';
 import 'package:oouchi_stock/i18n/app_localizations.dart';
 
-// 品種設定画面。カテゴリ別にタブで品種を一覧表示する
+/// 品種設定画面。カテゴリ別にタブで品種を一覧表示する
 class ItemTypeSettingsPage extends StatefulWidget {
-  /// 設定画面から渡されるカテゴリ一覧
   final List<Category> categories;
   const ItemTypeSettingsPage({super.key, required this.categories});
 
@@ -22,65 +17,32 @@ class ItemTypeSettingsPage extends StatefulWidget {
 }
 
 class _ItemTypeSettingsPageState extends State<ItemTypeSettingsPage> {
-  /// Firestore 監視用のサブスクリプション
-  late final StreamSubscription<QuerySnapshot<Map<String, dynamic>>> _sub;
-  /// 取得した品種リスト
-  List<ItemType> _list = [];
+  late final ItemTypeSettingsViewModel _viewModel;
 
   @override
   void initState() {
     super.initState();
-    // Firestore の itemTypes コレクションを監視し一覧を更新
-    _sub = userCollection('itemTypes')
-        .orderBy('createdAt')
-        .snapshots()
-        .listen((snapshot) async {
-      if (snapshot.docs.isEmpty) {
-        // データが無ければデフォルト品種を登録
-        await insertDefaultItemTypes();
-        return;
-      }
-      setState(() {
-        _list = snapshot.docs.map((d) {
-          final data = d.data();
-          return ItemType(
-            id: data['id'] ?? 0,
-            category: data['category'] ?? '',
-            name: data['name'] ?? '',
-            createdAt: parseDateTime(data['createdAt']),
-          );
-        }).toList();
-      });
-    });
+    _viewModel = ItemTypeSettingsViewModel()
+      ..addListener(() { if (mounted) setState(() {}); });
   }
 
   @override
   void dispose() {
-    // 画面破棄時にストリーム購読を解除
-    _sub.cancel();
+    _viewModel.dispose();
     super.dispose();
   }
 
   Future<void> _delete(ItemType item) async {
-    // 品種を削除する
     try {
-      final snapshot = await userCollection('itemTypes')
-          .where('id', isEqualTo: item.id)
-          .get();
-      for (final doc in snapshot.docs) {
-        await doc.reference.delete();
-      }
+      await _viewModel.delete(item);
       if (mounted) {
-        // 削除成功を通知
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(AppLocalizations.of(context)!.deleted)),
         );
       }
     } catch (e) {
-      // 例外内容をログに出力
       debugPrint('品種削除失敗: $e');
       if (mounted) {
-        // 削除失敗を通知
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text(AppLocalizations.of(context)!.deleteFailed)),
         );
@@ -88,9 +50,8 @@ class _ItemTypeSettingsPageState extends State<ItemTypeSettingsPage> {
     }
   }
 
-  /// 指定カテゴリの品種一覧を表示するリスト
   Widget _buildList(String category) {
-    final items = _list.where((e) => e.category == category).toList();
+    final items = _viewModel.list.where((e) => e.category == category).toList();
     return ListView(
       children: [
         for (final t in items)
@@ -105,8 +66,7 @@ class _ItemTypeSettingsPageState extends State<ItemTypeSettingsPage> {
                     children: [
                       ListTile(
                         leading: const Icon(Icons.edit),
-                        title:
-                            Text(AppLocalizations.of(context)!.itemTypeEditTitle),
+                        title: Text(AppLocalizations.of(context)!.itemTypeEditTitle),
                         onTap: () => Navigator.pop(context, 'edit'),
                       ),
                       ListTile(
@@ -139,7 +99,6 @@ class _ItemTypeSettingsPageState extends State<ItemTypeSettingsPage> {
 
   @override
   Widget build(BuildContext context) {
-    // カテゴリが存在しない場合は登録を促す画面を表示
     if (widget.categories.isEmpty) {
       return Scaffold(
         appBar: AppBar(title: Text(AppLocalizations.of(context)!.itemTypeSettingsTitle)),
@@ -147,7 +106,6 @@ class _ItemTypeSettingsPageState extends State<ItemTypeSettingsPage> {
       );
     }
     return DefaultTabController(
-      // カテゴリ数だけタブを生成
       length: widget.categories.length,
       child: Scaffold(
         appBar: AppBar(
@@ -159,7 +117,7 @@ class _ItemTypeSettingsPageState extends State<ItemTypeSettingsPage> {
                 SizedBox(
                   width: MediaQuery.of(context).size.width / 3,
                   child: Tab(text: c.name),
-                ),
+                )
             ],
           ),
         ),
@@ -169,7 +127,6 @@ class _ItemTypeSettingsPageState extends State<ItemTypeSettingsPage> {
           ],
         ),
         floatingActionButton: FloatingActionButton(
-          // 品種設定画面専用のヒーロータグ
           heroTag: 'itemTypeFab',
           onPressed: () async {
             await Navigator.push(

--- a/lib/presentation/viewmodels/home_page_viewmodel.dart
+++ b/lib/presentation/viewmodels/home_page_viewmodel.dart
@@ -1,0 +1,83 @@
+import 'dart:async';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import '../../util/firestore_refs.dart';
+import '../../util/date_time_parser.dart';
+import '../../domain/entities/inventory.dart';
+import '../../domain/entities/category.dart';
+import '../../domain/entities/category_order.dart';
+import '../../domain/entities/buy_list_condition_settings.dart';
+import '../../data/repositories/inventory_repository_impl.dart';
+import '../../domain/usecases/calculate_days_left.dart';
+import '../../data/repositories/buy_list_repository_impl.dart';
+import '../../domain/usecases/add_buy_item.dart';
+import '../../data/repositories/buy_prediction_repository_impl.dart';
+import '../../domain/usecases/watch_prediction_items.dart';
+import '../../domain/usecases/remove_prediction_item.dart';
+
+/// ホーム画面の状態を管理する ViewModel
+class HomePageViewModel extends ChangeNotifier {
+  /// カテゴリ一覧
+  List<Category> categories = [];
+
+  /// 読み込み完了フラグ
+  bool categoriesLoaded = false;
+
+  StreamSubscription<QuerySnapshot<Map<String, dynamic>>>? _catSub;
+
+  /// 買い物予報条件
+  BuyListConditionSettings? conditionSettings;
+
+  final CalculateDaysLeft _calcUsecase =
+      CalculateDaysLeft(InventoryRepositoryImpl());
+  final AddBuyItem _addBuyItem = AddBuyItem(BuyListRepositoryImpl());
+  final _predictionRepo = BuyPredictionRepositoryImpl();
+  late final WatchPredictionItems watchPrediction =
+      WatchPredictionItems(_predictionRepo);
+  late final RemovePredictionItem removePrediction =
+      RemovePredictionItem(_predictionRepo);
+
+  /// カテゴリ情報を読み込む
+  Future<void> loadCategories(List<Category>? initial) async {
+    if (initial != null && initial.isNotEmpty) {
+      categories = List<Category>.from(initial);
+      categories = await applyCategoryOrder(categories);
+      categoriesLoaded = true;
+      notifyListeners();
+    } else {
+      _catSub = userCollection('categories')
+          .orderBy('createdAt')
+          .snapshots()
+          .listen((snapshot) async {
+        var list = snapshot.docs.map((d) {
+          final data = d.data();
+          return Category(
+            id: data['id'] ?? 0,
+            name: data['name'] ?? '',
+            createdAt: parseDateTime(data['createdAt']),
+          );
+        }).toList();
+        list = await applyCategoryOrder(list);
+        categories = list;
+        categoriesLoaded = true;
+        notifyListeners();
+      });
+    }
+  }
+
+  /// 買い物予報条件を読み込む
+  Future<void> loadCondition() async {
+    final s = await loadBuyListConditionSettings();
+    conditionSettings = s;
+    notifyListeners();
+  }
+
+  /// 残り日数を計算
+  Future<int> calcDaysLeft(Inventory inv) => _calcUsecase(inv);
+
+  @override
+  void dispose() {
+    _catSub?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/presentation/viewmodels/inventory_detail_viewmodel.dart
+++ b/lib/presentation/viewmodels/inventory_detail_viewmodel.dart
@@ -1,0 +1,19 @@
+import '../../domain/repositories/inventory_repository.dart';
+import '../../domain/entities/inventory.dart';
+import '../../domain/entities/history_entry.dart';
+import '../../data/repositories/inventory_repository_impl.dart';
+
+/// 在庫詳細画面の状態を管理する ViewModel
+class InventoryDetailViewModel {
+  final String inventoryId;
+  final InventoryRepository repository;
+
+  InventoryDetailViewModel({required this.inventoryId, InventoryRepository? repository})
+      : repository = repository ?? InventoryRepositoryImpl();
+
+  /// 在庫を監視するストリーム
+  Stream<Inventory?> inventoryStream() => repository.watchInventory(inventoryId);
+
+  /// 履歴を監視するストリーム
+  Stream<List<HistoryEntry>> historyStream() => repository.watchHistory(inventoryId);
+}

--- a/lib/presentation/viewmodels/item_type_settings_viewmodel.dart
+++ b/lib/presentation/viewmodels/item_type_settings_viewmodel.dart
@@ -1,0 +1,56 @@
+import 'dart:async';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import '../../util/firestore_refs.dart';
+import '../../util/date_time_parser.dart';
+import '../../domain/entities/item_type.dart';
+import '../../default_item_types.dart';
+
+/// 品種設定画面の状態を管理する ViewModel
+class ItemTypeSettingsViewModel extends ChangeNotifier {
+  final StreamSubscription<QuerySnapshot<Map<String, dynamic>>> _sub;
+  List<ItemType> list = [];
+
+  ItemTypeSettingsViewModel() : _sub = userCollection('itemTypes')
+          .orderBy('createdAt')
+          .snapshots()
+          .listen((snapshot) async {}) {
+    _sub.onData((snapshot) async {
+      if (snapshot.docs.isEmpty) {
+        await insertDefaultItemTypes();
+        return;
+      }
+      list = snapshot.docs.map((d) {
+        final data = d.data();
+        return ItemType(
+          id: data['id'] ?? 0,
+          category: data['category'] ?? '',
+          name: data['name'] ?? '',
+          createdAt: parseDateTime(data['createdAt']),
+        );
+      }).toList();
+      notifyListeners();
+    });
+  }
+
+  /// 品種を削除する
+  Future<void> delete(ItemType item) async {
+    try {
+      final snapshot = await userCollection('itemTypes')
+          .where('id', isEqualTo: item.id)
+          .get();
+      for (final doc in snapshot.docs) {
+        await doc.reference.delete();
+      }
+    } catch (e) {
+      debugPrint('品種削除失敗: $e');
+      rethrow;
+    }
+  }
+
+  @override
+  void dispose() {
+    _sub.cancel();
+    super.dispose();
+  }
+}

--- a/lib/presentation/viewmodels/price_category_list_viewmodel.dart
+++ b/lib/presentation/viewmodels/price_category_list_viewmodel.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import '../../data/repositories/price_repository_impl.dart';
+import '../../domain/entities/price_info.dart';
+import '../../domain/usecases/watch_price_by_category.dart';
+
+/// セール情報管理画面のカテゴリタブを管理する ViewModel
+class PriceCategoryListViewModel extends ChangeNotifier {
+  final String category;
+  final WatchPriceByCategory _watch;
+
+  PriceCategoryListViewModel({required this.category, WatchPriceByCategory? watch})
+      : _watch = watch ?? WatchPriceByCategory(PriceRepositoryImpl());
+
+  /// 検索文字列
+  String search = '';
+
+  /// 並び替え条件
+  String sort = 'updated';
+
+  /// 期限切れを表示するか
+  bool showExpired = false;
+
+  /// 入力コントローラー
+  final TextEditingController controller = TextEditingController();
+
+  /// セール情報ストリーム
+  Stream<List<PriceInfo>> get stream => _watch(category);
+
+  /// 検索文字列を更新
+  void setSearch(String v) {
+    search = v;
+    notifyListeners();
+  }
+
+  /// 並び替え条件を更新
+  void setSort(String v) {
+    sort = v;
+    notifyListeners();
+  }
+
+  /// 期限切れ表示設定を更新
+  void setShowExpired(bool v) {
+    showExpired = v;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+}

--- a/lib/presentation/viewmodels/price_detail_viewmodel.dart
+++ b/lib/presentation/viewmodels/price_detail_viewmodel.dart
@@ -1,0 +1,7 @@
+import '../../domain/entities/price_info.dart';
+
+/// セール詳細情報画面の ViewModel
+class PriceDetailViewModel {
+  final PriceInfo info;
+  PriceDetailViewModel(this.info);
+}

--- a/lib/presentation/viewmodels/price_history_viewmodel.dart
+++ b/lib/presentation/viewmodels/price_history_viewmodel.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import '../../data/repositories/price_repository_impl.dart';
+import '../../domain/entities/price_info.dart';
+import '../../domain/usecases/delete_price_info.dart';
+import '../../domain/usecases/watch_price_by_type.dart';
+
+/// セール情報履歴画面の状態を管理する ViewModel
+class PriceHistoryViewModel {
+  final String category;
+  final String itemType;
+  final WatchPriceByType watch;
+  final DeletePriceInfo deleter;
+
+  PriceHistoryViewModel({
+    required this.category,
+    required this.itemType,
+    WatchPriceByType? watch,
+    DeletePriceInfo? deleter,
+  })  : watch = watch ?? WatchPriceByType(PriceRepositoryImpl()),
+        deleter = deleter ?? DeletePriceInfo(PriceRepositoryImpl());
+
+  /// セール情報ストリーム
+  Stream<List<PriceInfo>> stream() => watch(category, itemType);
+
+  /// 指定 ID を削除
+  Future<void> delete(String id) => deleter(id);
+}

--- a/lib/presentation/viewmodels/price_list_viewmodel.dart
+++ b/lib/presentation/viewmodels/price_list_viewmodel.dart
@@ -1,0 +1,48 @@
+import 'dart:async';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import '../../domain/entities/category.dart';
+import '../../domain/entities/category_order.dart';
+import '../../util/firestore_refs.dart';
+import '../../util/date_time_parser.dart';
+
+/// セール情報管理画面全体の状態を管理する ViewModel
+class PriceListViewModel extends ChangeNotifier {
+  /// カテゴリ一覧
+  List<Category> categories = [];
+
+  /// 読み込み完了フラグ
+  bool loaded = false;
+
+  StreamSubscription<QuerySnapshot<Map<String, dynamic>>>? _sub;
+
+  /// Firestore からカテゴリを読み込み監視する
+  Future<void> load() async {
+    _sub = userCollection('categories')
+        .orderBy('createdAt')
+        .snapshots()
+        .listen((snapshot) async {
+      var list = snapshot.docs.map((d) {
+        final data = d.data();
+        return Category(
+          id: data['id'] ?? 0,
+          name: data['name'] ?? '',
+          createdAt: parseDateTime(data['createdAt']),
+        );
+      }).toList();
+      list = await applyCategoryOrder(list);
+      categories = list;
+      loaded = true;
+      notifyListeners();
+    }, onError: (_) {
+      loaded = true;
+      notifyListeners();
+    });
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/presentation/viewmodels/sale_list_viewmodel.dart
+++ b/lib/presentation/viewmodels/sale_list_viewmodel.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import '../../data/repositories/buy_list_repository_impl.dart';
+import '../../domain/entities/buy_item.dart';
+import '../../domain/usecases/add_buy_item.dart';
+import '../../models/sale_item.dart';
+
+/// 買い得リスト画面の状態を管理する ViewModel
+class SaleListViewModel extends ChangeNotifier {
+  /// 表示するセール情報一覧
+  final List<SaleItem> items = [
+    SaleItem(
+      name: 'コーヒー豆 200g',
+      shop: 'Amazon',
+      regularPrice: 1200,
+      salePrice: 980,
+      start: DateTime.now().subtract(const Duration(days: 1)),
+      end: DateTime.now().add(const Duration(days: 2)),
+      stock: 5,
+      recommended: true,
+      lowest: true,
+    ),
+    SaleItem(
+      name: 'トイレットペーパー 12ロール',
+      shop: '楽天',
+      regularPrice: 600,
+      salePrice: 480,
+      start: DateTime.now(),
+      end: DateTime.now().add(const Duration(days: 5)),
+      stock: 20,
+    ),
+    SaleItem(
+      name: '洗剤 詰め替え用',
+      shop: '近所のスーパー',
+      regularPrice: 350,
+      salePrice: 300,
+      start: DateTime.now().subtract(const Duration(days: 2)),
+      end: DateTime.now().add(const Duration(days: 1)),
+      stock: 1,
+    ),
+  ];
+
+  /// 通知オン/オフ
+  bool notify = true;
+
+  /// 並び替え条件
+  String sort = 'end';
+
+  final AddBuyItem addBuyItem = AddBuyItem(BuyListRepositoryImpl());
+
+  /// 並び替え後のリストを取得
+  List<SaleItem> get sortedItems {
+    final sorted = List<SaleItem>.from(items);
+    sorted.sort((a, b) {
+      if (sort == 'discount') {
+        final ad = (a.regularPrice - a.salePrice) / a.regularPrice;
+        final bd = (b.regularPrice - b.salePrice) / b.regularPrice;
+        return bd.compareTo(ad);
+      } else if (sort == 'unit') {
+        return a.salePrice.compareTo(b.salePrice);
+      } else if (sort == 'recommend') {
+        if (a.recommended == b.recommended) return 0;
+        return a.recommended ? -1 : 1;
+      }
+      return a.end.compareTo(b.end);
+    });
+    return sorted;
+  }
+
+  /// 並び替え条件を更新
+  void updateSort(String value) {
+    sort = value;
+    notifyListeners();
+  }
+
+  /// 通知設定を更新
+  void updateNotify(bool value) {
+    notify = value;
+    notifyListeners();
+  }
+}

--- a/lib/presentation/viewmodels/settings_viewmodel.dart
+++ b/lib/presentation/viewmodels/settings_viewmodel.dart
@@ -1,0 +1,118 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../../util/firestore_refs.dart';
+import '../../data/repositories/ad_config_repository_impl.dart';
+import '../../domain/usecases/load_ad_enabled.dart';
+import '../../domain/usecases/save_ad_enabled.dart';
+
+/// 設定画面の状態を管理する ViewModel
+class SettingsViewModel extends ChangeNotifier {
+  /// 最後にバックアップした日時
+  DateTime? backupTime;
+
+  /// 最後に復元した日時
+  DateTime? restoredTime;
+
+  /// 広告表示設定
+  bool adsEnabled = true;
+
+  final LoadAdEnabled _loadAdEnabled;
+  final SaveAdEnabled _saveAdEnabled;
+
+  SettingsViewModel()
+      : _loadAdEnabled = LoadAdEnabled(AdConfigRepositoryImpl()),
+        _saveAdEnabled = SaveAdEnabled(AdConfigRepositoryImpl()) {
+    loadTimes();
+    loadAds();
+  }
+
+  /// バックアップ・復元日時を読み込む
+  Future<void> loadTimes() async {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) return;
+    final prefs = await SharedPreferences.getInstance();
+    final backupStr = prefs.getString('backup_time_\$uid');
+    final restoreStr = prefs.getString('restore_time_\$uid');
+    backupTime = backupStr != null ? DateTime.parse(backupStr) : null;
+    restoredTime = restoreStr != null ? DateTime.parse(restoreStr) : null;
+    notifyListeners();
+  }
+
+  /// 広告設定を読み込む
+  Future<void> loadAds() async {
+    adsEnabled = await _loadAdEnabled();
+    notifyListeners();
+  }
+
+  /// 広告設定を保存する
+  Future<void> saveAds(bool value) async {
+    await _saveAdEnabled(value);
+    adsEnabled = value;
+    notifyListeners();
+  }
+
+  /// データをバックアップする
+  Future<void> backup() async {
+    final uid = FirebaseAuth.instance.currentUser!.uid;
+    final prefs = await SharedPreferences.getInstance();
+    final catSnap = await userCollection('categories').get();
+    final invSnap = await userCollection('inventory').get();
+    final data = {
+      'categories': catSnap.docs.map((d) {
+        final m = d.data();
+        final ts = m['createdAt'];
+        if (ts is Timestamp) m['createdAt'] = ts.toDate().toIso8601String();
+        return m;
+      }).toList(),
+      'inventory': invSnap.docs.map((d) {
+        final m = d.data();
+        final ts = m['createdAt'];
+        if (ts is Timestamp) m['createdAt'] = ts.toDate().toIso8601String();
+        return m;
+      }).toList(),
+    };
+    final now = DateTime.now();
+    await prefs.setString('backup_$uid', jsonEncode(data));
+    await prefs.setString('backup_time_$uid', now.toIso8601String());
+    backupTime = now;
+    notifyListeners();
+  }
+
+  /// バックアップデータから復元する
+  Future<DateTime> restore() async {
+    final uid = FirebaseAuth.instance.currentUser!.uid;
+    final prefs = await SharedPreferences.getInstance();
+    final text = prefs.getString('backup_$uid');
+    final timeStr = prefs.getString('backup_time_$uid');
+    if (text == null || timeStr == null) {
+      throw Exception('no backup');
+    }
+    final backupTime = DateTime.parse(timeStr);
+    final data = jsonDecode(text);
+    final batch = FirebaseFirestore.instance.batch();
+    final catRef = userCollection('categories');
+    final invRef = userCollection('inventory');
+    final catDocs = await catRef.get();
+    for (final d in catDocs.docs) {
+      batch.delete(d.reference);
+    }
+    final invDocs = await invRef.get();
+    for (final d in invDocs.docs) {
+      batch.delete(d.reference);
+    }
+    for (final c in (data['categories'] as List)) {
+      batch.set(catRef.doc(), Map<String, dynamic>.from(c));
+    }
+    for (final i in (data['inventory'] as List)) {
+      batch.set(invRef.doc(), Map<String, dynamic>.from(i));
+    }
+    await batch.commit();
+    await prefs.setString('restore_time_$uid', backupTime.toIso8601String());
+    restoredTime = backupTime;
+    notifyListeners();
+    return backupTime;
+  }
+}

--- a/lib/price_detail_page.dart
+++ b/lib/price_detail_page.dart
@@ -1,20 +1,19 @@
 import 'package:flutter/material.dart';
 import 'i18n/app_localizations.dart';
-import 'domain/entities/price_info.dart';
+import 'presentation/viewmodels/price_detail_viewmodel.dart';
+import "domain/entities/price_info.dart";
 
 /// セール詳細情報表示画面
 class PriceDetailPage extends StatelessWidget {
-  /// 表示するセール情報
-  final PriceInfo info;
-
-  const PriceDetailPage({super.key, required this.info});
+  final PriceDetailViewModel viewModel;
+  PriceDetailPage({super.key, required PriceInfo info}) : viewModel = PriceDetailViewModel(info);
 
   @override
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
+    final info = viewModel.info;
     final textStyle = Theme.of(context).textTheme.bodyLarge?.copyWith(fontSize: 18);
     return Scaffold(
-      // タイトルには商品名があれば商品名、なければ品種名を使用
       appBar: AppBar(title: Text(info.itemName.isNotEmpty ? info.itemName : info.itemType)),
       body: ListView(
         padding: const EdgeInsets.all(16),
@@ -38,10 +37,8 @@ class PriceDetailPage extends StatelessWidget {
     );
   }
 
-  /// 日付を yyyy/MM/dd 形式で返す
   String _formatDate(DateTime d) => '${d.year}/${d.month}/${d.day}';
 
-  /// 項目名と値を左右に表示する行を生成
   Widget _buildRow(String label, String value, [TextStyle? style]) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),

--- a/lib/sale_list_page.dart
+++ b/lib/sale_list_page.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/material.dart';
 import 'i18n/app_localizations.dart';
-import 'data/repositories/buy_list_repository_impl.dart';
-import 'domain/entities/buy_item.dart';
-import 'domain/usecases/add_buy_item.dart';
-import 'models/sale_item.dart';
+import 'presentation/viewmodels/sale_list_viewmodel.dart';
 import 'util/localization_extensions.dart';
 import 'widgets/sale_item_card.dart';
 
@@ -16,82 +13,28 @@ class SaleListPage extends StatefulWidget {
 }
 
 class _SaleListPageState extends State<SaleListPage> {
-  // サンプルデータ
-  final List<SaleItem> _items = [
-    SaleItem(
-      name: 'コーヒー豆 200g',
-      shop: 'Amazon',
-      regularPrice: 1200,
-      salePrice: 980,
-      start: DateTime.now().subtract(const Duration(days: 1)),
-      end: DateTime.now().add(const Duration(days: 2)),
-      stock: 5,
-      recommended: true,
-      lowest: true,
-    ),
-    SaleItem(
-      name: 'トイレットペーパー 12ロール',
-      shop: '楽天',
-      regularPrice: 600,
-      salePrice: 480,
-      start: DateTime.now(),
-      end: DateTime.now().add(const Duration(days: 5)),
-      stock: 20,
-    ),
-    SaleItem(
-      name: '洗剤 詰め替え用',
-      shop: '近所のスーパー',
-      regularPrice: 350,
-      salePrice: 300,
-      start: DateTime.now().subtract(const Duration(days: 2)),
-      end: DateTime.now().add(const Duration(days: 1)),
-      stock: 1,
-    ),
-  ];
+  late final SaleListViewModel _viewModel;
 
-  bool _notify = true; // 通知設定
-
-  // 並び替え方法。"end"=終了日近い順、"discount"=割引率順、
-  // "unit"=単価安い順、"recommend"=おすすめ順
-  String _sort = 'end';
-
-  // 買い物リストへ追加するユースケース
-  final AddBuyItem _addBuyItem = AddBuyItem(BuyListRepositoryImpl());
+  @override
+  void initState() {
+    super.initState();
+    _viewModel = SaleListViewModel()..addListener(() { if (mounted) setState(() {}); });
+  }
 
   @override
   Widget build(BuildContext context) {
-    // 買い得リスト画面のビルド。並び替えや通知設定の状態を反映する
     final loc = AppLocalizations.of(context)!;
-    // 並び替え
-    final sorted = List<SaleItem>.from(_items);
-    sorted.sort((a, b) {
-      if (_sort == 'discount') {
-        final ad = (a.regularPrice - a.salePrice) / a.regularPrice;
-        final bd = (b.regularPrice - b.salePrice) / b.regularPrice;
-        return bd.compareTo(ad);
-      } else if (_sort == 'unit') {
-        final au = a.salePrice;
-        final bu = b.salePrice;
-        return au.compareTo(bu);
-      } else if (_sort == 'recommend') {
-        if (a.recommended == b.recommended) return 0;
-        return a.recommended ? -1 : 1;
-      }
-      return a.end.compareTo(b.end);
-    });
-
+    final sorted = _viewModel.sortedItems;
     return Scaffold(
       appBar: AppBar(
-        // 画面タイトル
         title: Text(loc.saleListTitle()),
         actions: [
           Row(
             children: [
-              // セール通知設定スイッチのラベル
               Text(loc.saleNotify()),
               Switch(
-                value: _notify,
-                onChanged: (v) => setState(() => _notify = v),
+                value: _viewModel.notify,
+                onChanged: (v) => _viewModel.updateNotify(v),
               ),
             ],
           ),
@@ -105,34 +48,29 @@ class _SaleListPageState extends State<SaleListPage> {
               spacing: 8,
               children: [
                 ChoiceChip(
-                  // セール終了日が近い順に並び替え
                   label: Text(loc.sortEndDate()),
-                  selected: _sort == 'end',
-                  onSelected: (_) => setState(() => _sort = 'end'),
+                  selected: _viewModel.sort == 'end',
+                  onSelected: (_) => _viewModel.updateSort('end'),
                 ),
                 ChoiceChip(
-                  // 割引率の高い順に並び替え
                   label: Text(loc.sortDiscount()),
-                  selected: _sort == 'discount',
-                  onSelected: (_) => setState(() => _sort = 'discount'),
+                  selected: _viewModel.sort == 'discount',
+                  onSelected: (_) => _viewModel.updateSort('discount'),
                 ),
                 ChoiceChip(
-                  // 単価が安い順に並び替え
                   label: Text(loc.sortUnitPrice),
-                  selected: _sort == 'unit',
-                  onSelected: (_) => setState(() => _sort = 'unit'),
+                  selected: _viewModel.sort == 'unit',
+                  onSelected: (_) => _viewModel.updateSort('unit'),
                 ),
                 ChoiceChip(
-                  // おすすめ度順に並び替え
                   label: Text(loc.sortRecommend()),
-                  selected: _sort == 'recommend',
-                  onSelected: (_) => setState(() => _sort = 'recommend'),
+                  selected: _viewModel.sort == 'recommend',
+                  onSelected: (_) => _viewModel.updateSort('recommend'),
                 ),
               ],
             ),
           ),
           Expanded(
-            // セール情報をリスト表示
             child: ListView.builder(
               padding: const EdgeInsets.all(16),
               itemCount: sorted.length,
@@ -140,7 +78,7 @@ class _SaleListPageState extends State<SaleListPage> {
                 final item = sorted[index];
                 return SaleItemCard(
                   item: item,
-                  addUsecase: _addBuyItem,
+                  addUsecase: _viewModel.addBuyItem,
                 );
               },
             ),

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -4,16 +4,9 @@ import 'category_settings_page.dart';
 import 'item_type_settings_page.dart';
 import 'language_settings_page.dart';
 import 'buy_list_condition_settings_page.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:intl/intl.dart';
-import 'dart:convert';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'util/firestore_refs.dart';
+import 'presentation/viewmodels/settings_viewmodel.dart';
 import 'domain/entities/category.dart';
-import 'data/repositories/ad_config_repository_impl.dart';
-import 'domain/usecases/load_ad_enabled.dart';
-import 'domain/usecases/save_ad_enabled.dart';
 
 /// 設定画面。カテゴリ設定ページへの遷移を提供する
 class SettingsPage extends StatefulWidget {
@@ -34,54 +27,22 @@ class SettingsPage extends StatefulWidget {
 }
 
 class _SettingsPageState extends State<SettingsPage> {
-  /// 最後にバックアップした日時
-  DateTime? _backupTime;
-
-  /// 最後に復元したバックアップデータの日時
-  DateTime? _restoredTime;
-
-  /// 広告を表示するかどうかの設定
-  bool _adsEnabled = true;
+  late final SettingsViewModel _viewModel;
 
   @override
   void initState() {
     super.initState();
-    // 起動時にバックアップ・復元日時を読み込む
-    _loadTimes();
-    _loadAds();
+    _viewModel = SettingsViewModel()
+      ..addListener(() { if (mounted) setState(() {}); });
   }
 
-  /// SharedPreferences からバックアップ・復元日時を取得して状態に反映
-  Future<void> _loadTimes() async {
-    final uid = FirebaseAuth.instance.currentUser?.uid;
-    if (uid == null) return;
-    final prefs = await SharedPreferences.getInstance();
-    final backupStr = prefs.getString('backup_time_\$uid');
-    final restoreStr = prefs.getString('restore_time_\$uid');
-    if (!mounted) return;
-    setState(() {
-      _backupTime = backupStr != null ? DateTime.parse(backupStr) : null;
-      _restoredTime = restoreStr != null ? DateTime.parse(restoreStr) : null;
-    });
+  @override
+  void dispose() {
+    _viewModel.dispose();
+    super.dispose();
   }
 
-  /// SharedPreferences から広告設定を読み込む
-  Future<void> _loadAds() async {
-    final usecase = LoadAdEnabled(AdConfigRepositoryImpl());
-    final enabled = await usecase();
-    if (mounted) {
-      setState(() => _adsEnabled = enabled);
-    }
-  }
-
-  /// 広告設定を保存する
-  Future<void> _saveAds(bool value) async {
-    final usecase = SaveAdEnabled(AdConfigRepositoryImpl());
-    await usecase(value);
-    setState(() => _adsEnabled = value);
-  }
-  /// 設定画面の「バックアップ」タップ時に呼び出される
-  /// 実行前に確認ダイアログを表示する
+  /// バックアップボタン押下時に実行
   Future<void> _backup() async {
     final loc = AppLocalizations.of(context)!;
     final result = await showDialog<bool>(
@@ -95,104 +56,51 @@ class _SettingsPageState extends State<SettingsPage> {
       ),
     );
     if (result != true) return;
-
-    final uid = FirebaseAuth.instance.currentUser!.uid;
-    final prefs = await SharedPreferences.getInstance();
-    final catSnap = await userCollection('categories').get();
-    final invSnap = await userCollection('inventory').get();
-    final data = {
-      'categories': catSnap.docs.map((d) {
-        final m = d.data();
-        final ts = m['createdAt'];
-        // Firestore Timestamp を ISO8601 文字列に変換する
-        if (ts is Timestamp) m['createdAt'] = ts.toDate().toIso8601String();
-        return m;
-      }).toList(),
-      'inventory': invSnap.docs.map((d) {
-        final m = d.data();
-        final ts = m['createdAt'];
-        // Firestore Timestamp を ISO8601 文字列に変換する
-        if (ts is Timestamp) m['createdAt'] = ts.toDate().toIso8601String();
-        return m;
-      }).toList(),
-    };
-    final now = DateTime.now();
-    await prefs.setString('backup_$uid', jsonEncode(data));
-    await prefs.setString('backup_time_$uid', now.toIso8601String());
-    if (mounted) {
-      final time = DateFormat('yyyy/MM/dd HH:mm').format(now);
-      setState(() {
-        _backupTime = now;
-      });
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(loc.backupDoneWithTime(time))),
-      );
-    }
+    await _viewModel.backup();
+    if (!mounted) return;
+    final time = DateFormat('yyyy/MM/dd HH:mm').format(_viewModel.backupTime!);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(loc.backupDoneWithTime(time))),
+    );
   }
 
-  /// 設定画面の「復元」タップ時に呼び出される
-  /// SharedPreferences に保存したバックアップからデータを復元する
+  /// 復元ボタン押下時に実行
   Future<void> _restore() async {
-    final uid = FirebaseAuth.instance.currentUser!.uid;
-    final prefs = await SharedPreferences.getInstance();
-    final text = prefs.getString('backup_$uid');
-    final timeStr = prefs.getString('backup_time_$uid');
-    if (text == null || timeStr == null) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(AppLocalizations.of(context)!.noBackupData)),
-        );
-      }
+    final loc = AppLocalizations.of(context)!;
+    final backupTime = _viewModel.backupTime;
+    if (backupTime == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(loc.noBackupData)),
+      );
       return;
     }
-    final backupTime = DateTime.parse(timeStr);
     final formatted = DateFormat('yyyy/MM/dd HH:mm').format(backupTime);
-
     final confirm = await showDialog<bool>(
       context: context,
       builder: (_) => AlertDialog(
-        content: Text(AppLocalizations.of(context)!.restoreConfirm(formatted)),
+        content: Text(loc.restoreConfirm(formatted)),
         actions: [
-          TextButton(
-              onPressed: () => Navigator.pop(context, false),
-              child: Text(AppLocalizations.of(context)!.cancel)),
-          TextButton(
-              onPressed: () => Navigator.pop(context, true),
-              child: Text(AppLocalizations.of(context)!.ok)),
+          TextButton(onPressed: () => Navigator.pop(context, false), child: Text(loc.cancel)),
+          TextButton(onPressed: () => Navigator.pop(context, true), child: Text(loc.ok)),
         ],
       ),
     );
     if (confirm != true) return;
-
-    final data = jsonDecode(text);
-    final batch = FirebaseFirestore.instance.batch();
-    final catRef = userCollection('categories');
-    final invRef = userCollection('inventory');
-    final catDocs = await catRef.get();
-    for (final d in catDocs.docs) {
-      batch.delete(d.reference);
-    }
-    final invDocs = await invRef.get();
-    for (final d in invDocs.docs) {
-      batch.delete(d.reference);
-    }
-    for (final c in (data['categories'] as List)) {
-      batch.set(catRef.doc(), Map<String, dynamic>.from(c));
-    }
-    for (final i in (data['inventory'] as List)) {
-      batch.set(invRef.doc(), Map<String, dynamic>.from(i));
-    }
-    await batch.commit();
-    await prefs.setString('restore_time_$uid', backupTime.toIso8601String());
-    if (mounted) {
-      setState(() {
-        _restoredTime = backupTime;
-      });
+    try {
+      final time = await _viewModel.restore();
+      if (!mounted) return;
+      final t = DateFormat('yyyy/MM/dd HH:mm').format(time);
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(AppLocalizations.of(context)!.restoreDoneWithTime(formatted))),
+        SnackBar(content: Text(loc.restoreDoneWithTime(t))),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(loc.noBackupData)),
       );
     }
   }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -213,74 +121,71 @@ class _SettingsPageState extends State<SettingsPage> {
               );
             },
           ),
-        ListTile(
-          title: Text(AppLocalizations.of(context)!.itemTypeSettings),
-          onTap: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (_) => ItemTypeSettingsPage(categories: widget.categories),
-              ),
-            );
-          },
-        ),
-        ListTile(
-          title: Text(AppLocalizations.of(context)!.language),
-          onTap: () async {
-            final locale = await Navigator.push<Locale>(
-              context,
-              MaterialPageRoute(
-                builder: (_) => LanguageSettingsPage(
-                  current: Localizations.localeOf(context),
-                  onSelected: (l) => Navigator.pop(context, l),
+          ListTile(
+            title: Text(AppLocalizations.of(context)!.itemTypeSettings),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => ItemTypeSettingsPage(categories: widget.categories),
                 ),
-              ),
-            );
-            if (locale != null) widget.onLocaleChanged(locale);
-          },
-        ),
-        ListTile(
-          title: Text(AppLocalizations.of(context)!.buyListConditionSettings),
-          onTap: () async {
-            final changed = await Navigator.push<bool>(
-              context,
-              MaterialPageRoute(
-                builder: (_) => const BuyListConditionSettingsPage(),
-              ),
-            );
-            if (changed == true) widget.onConditionChanged();
-          },
-        ),
-        SwitchListTile(
-          title: Text(AppLocalizations.of(context)!.showAds),
-          value: _adsEnabled,
-          onChanged: (v) => _saveAds(v),
-        ),
-        ListTile(
-          key: const Key('backupTile'),
-          title: Text(AppLocalizations.of(context)!.backup),
-          // 最後にバックアップした日時を表示。未実行なら"未バックアップ"を表示
-          trailing: Text(
-            _backupTime != null
-                ? DateFormat('yyyy/MM/dd HH:mm').format(_backupTime!)
-                : AppLocalizations.of(context)!.noBackupYet,
+              );
+            },
           ),
-          onTap: _backup,
-        ),
-        ListTile(
-          key: const Key('restoreTile'),
-          title: Text(AppLocalizations.of(context)!.restore),
-          // 最後にバックアップから復元した日時を表示。未実行なら"未復元"を表示
-          trailing: Text(
-            _restoredTime != null
-                ? DateFormat('yyyy/MM/dd HH:mm').format(_restoredTime!)
-                : AppLocalizations.of(context)!.noRestoreYet,
+          ListTile(
+            title: Text(AppLocalizations.of(context)!.language),
+            onTap: () async {
+              final locale = await Navigator.push<Locale>(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => LanguageSettingsPage(
+                    current: Localizations.localeOf(context),
+                    onSelected: (l) => Navigator.pop(context, l),
+                  ),
+                ),
+              );
+              if (locale != null) widget.onLocaleChanged(locale);
+            },
           ),
-          onTap: _restore,
-        ),
-      ],
-    ),
-  );
+          ListTile(
+            title: Text(AppLocalizations.of(context)!.buyListConditionSettings),
+            onTap: () async {
+              final changed = await Navigator.push<bool>(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => const BuyListConditionSettingsPage(),
+                ),
+              );
+              if (changed == true) widget.onConditionChanged();
+            },
+          ),
+          SwitchListTile(
+            title: Text(AppLocalizations.of(context)!.showAds),
+            value: _viewModel.adsEnabled,
+            onChanged: (v) => _viewModel.saveAds(v),
+          ),
+          ListTile(
+            key: const Key('backupTile'),
+            title: Text(AppLocalizations.of(context)!.backup),
+            trailing: Text(
+              _viewModel.backupTime != null
+                  ? DateFormat('yyyy/MM/dd HH:mm').format(_viewModel.backupTime!)
+                  : AppLocalizations.of(context)!.noBackupYet,
+            ),
+            onTap: _backup,
+          ),
+          ListTile(
+            key: const Key('restoreTile'),
+            title: Text(AppLocalizations.of(context)!.restore),
+            trailing: Text(
+              _viewModel.restoredTime != null
+                  ? DateFormat('yyyy/MM/dd HH:mm').format(_viewModel.restoredTime!)
+                  : AppLocalizations.of(context)!.noRestoreYet,
+            ),
+            onTap: _restore,
+          ),
+        ],
+      ),
+    );
   }
 }
-


### PR DESCRIPTION
## Summary
- ViewModel を追加し各画面の状態管理を分離
- 既存ページを ViewModel 利用に書き換え

## Testing
- `flutter test` (failed: command not found)

------
https://chatgpt.com/codex/tasks/task_e_685ab134164c832e93f583ea08a6f5b8