### PR TITLE
ビルドエラー解消

### DIFF
--- a/lib/presentation/viewmodels/home_page_viewmodel.dart
+++ b/lib/presentation/viewmodels/home_page_viewmodel.dart
@@ -37,6 +37,16 @@ class HomePageViewModel extends ChangeNotifier {
   late final RemovePredictionItem removePrediction =
       RemovePredictionItem(_predictionRepo);
 
+  /// 買い物リストへ商品を追加するユースケースを公開
+  AddBuyItem get addBuyItem => _addBuyItem;
+
+  /// 設定画面から戻った際などにカテゴリリストを更新する
+  void updateCategories(List<Category> list) {
+    categories = List<Category>.from(list);
+    categoriesLoaded = true;
+    notifyListeners();
+  }
+
   /// カテゴリ情報を読み込む
   Future<void> loadCategories(List<Category>? initial) async {
     if (initial != null && initial.isNotEmpty) {

--- a/lib/price_list_page.dart
+++ b/lib/price_list_page.dart
@@ -8,6 +8,8 @@ import 'presentation/viewmodels/price_category_list_viewmodel.dart';
 import 'price_detail_page.dart';
 import 'main.dart';
 import 'widgets/scrolling_text.dart';
+import 'domain/entities/price_info.dart';
+import 'domain/usecases/watch_price_by_category.dart';
 
 /// セール情報管理画面
 class PriceListPage extends StatefulWidget {


### PR DESCRIPTION
## 変更内容
- PriceListPage に必要なインポートを追加
- HomePageViewModel にカテゴリ更新メソッドと AddBuyItem 取得用ゲッターを実装

## テスト
- `flutter test` を実行しようとしましたが、環境に Flutter が存在せず実行できませんでした

------
https://chatgpt.com/codex/tasks/task_e_685ab500c090832e8b1a81d100f99881