### PR TITLE
ViewModelの依存関係整理

### DIFF
--- a/docs/architecture_proposals_ja.md
+++ b/docs/architecture_proposals_ja.md
@@ -20,6 +20,7 @@
 ## 3. MVVM などのパターン
 - Clean Architecture をベースに、プレゼンテーション層では MVVM や Presenter パターンを採用する方法もあります。
 - ViewModel が UseCase を呼び出し、画面は ViewModel を監視するだけにすると見通しが良くなります。
+- ウィジェットでは UseCase や Repository を直接扱わず、処理はすべて ViewModel 経由で行います。
 - 例として `AddInventoryPage` をはじめ、カテゴリの追加・編集画面やセール情報追加画面も
   ViewModel (`AddCategoryViewModel`, `EditCategoryViewModel`, `EditInventoryViewModel` など) で状態管理するようリファクタリングしました。
   さらに在庫一覧画面でも `InventoryPageViewModel` と `InventoryListViewModel` を導入し、

--- a/lib/buy_list_page.dart
+++ b/lib/buy_list_page.dart
@@ -1,22 +1,9 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
-import 'util/firestore_refs.dart';
-import 'util/date_time_parser.dart';
 import 'package:oouchi_stock/i18n/app_localizations.dart';
-import 'data/repositories/buy_list_repository_impl.dart';
-import 'domain/entities/buy_item.dart';
-import 'domain/usecases/add_buy_item.dart';
-import 'domain/usecases/remove_buy_item.dart';
-import 'domain/usecases/watch_buy_items.dart';
 import 'presentation/viewmodels/buy_list_viewmodel.dart';
-
-import 'data/repositories/inventory_repository_impl.dart';
-import 'domain/repositories/inventory_repository.dart';
+import 'domain/entities/buy_item.dart';
 import 'domain/entities/category.dart';
-import 'domain/entities/inventory.dart';
-import 'domain/entities/buy_list_condition_settings.dart';
-import 'domain/services/buy_list_strategy.dart';
-import 'domain/entities/category_order.dart';
 import 'widgets/settings_menu_button.dart';
 import 'widgets/buy_list_card.dart';
 // 言語変更時にアプリ全体のロケールを更新するため MyAppState を参照
@@ -27,14 +14,14 @@ import 'main.dart';
 class BuyListPage extends StatefulWidget {
   /// 外部から渡されるカテゴリ一覧
   final List<Category>? categories;
-  /// 在庫データ取得用リポジトリ
-  final InventoryRepository repository;
+  /// テスト用に ViewModel を差し替え可能
+  final BuyListViewModel? viewModel;
 
   BuyListPage({
     super.key,
     this.categories,
-    InventoryRepository? repository,
-  }) : repository = repository ?? InventoryRepositoryImpl();
+    this.viewModel,
+  });
 
   @override
   State<BuyListPage> createState() => BuyListPageState();
@@ -48,13 +35,7 @@ class BuyListPageState extends State<BuyListPage> {
   @override
   void initState() {
     super.initState();
-    final buyRepo = BuyListRepositoryImpl();
-    _viewModel = BuyListViewModel(
-      repository: widget.repository,
-      addUsecase: AddBuyItem(buyRepo),
-      removeUsecase: RemoveBuyItem(buyRepo),
-      watchUsecase: WatchBuyItems(buyRepo),
-    );
+    _viewModel = widget.viewModel ?? BuyListViewModel();
     _viewModel.addListener(() {
       if (mounted) setState(() {});
     });
@@ -134,7 +115,9 @@ class BuyListPageState extends State<BuyListPage> {
                             BuyListCard(
                               item: item,
                               categories: _viewModel.categories,
-                              repository: widget.repository,
+                              watchInventory: _viewModel.watchInventory,
+                              calcDaysLeft: _viewModel.calcDaysLeft,
+                              updateQuantity: _viewModel.updateQuantity,
                               onRemove: _viewModel.removeItem,
                             ),
                         ],

--- a/lib/edit_category_page.dart
+++ b/lib/edit_category_page.dart
@@ -3,8 +3,6 @@ import 'package:oouchi_stock/i18n/app_localizations.dart';
 import 'util/firestore_refs.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'presentation/viewmodels/edit_category_viewmodel.dart';
-import 'domain/usecases/update_category.dart';
-import 'data/repositories/category_repository_impl.dart';
 
 import 'domain/entities/category.dart';
 
@@ -24,10 +22,7 @@ class _EditCategoryPageState extends State<EditCategoryPage> {
   @override
   void initState() {
     super.initState();
-    _viewModel = EditCategoryViewModel(
-      UpdateCategory(CategoryRepositoryImpl()),
-      widget.category,
-    );
+    _viewModel = EditCategoryViewModel(widget.category);
     _viewModel.addListener(() {
       if (mounted) setState(() {});
     });

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -125,9 +125,9 @@ class _HomePageState extends State<HomePage> {
                               PredictionCard(
                                 item: item,
                                 categories: _viewModel.categories,
-                                repository: InventoryRepositoryImpl(),
-                                addUsecase: _viewModel.addBuyItem,
-                                removeUsecase: _viewModel.removePrediction,
+                                watchInventory: _viewModel.watchInventory,
+                                addToBuyList: _viewModel.addPredictionToBuyList,
+                                removePrediction: _viewModel.removePredictionItem,
                                 calcDaysLeft: _viewModel.calcDaysLeft,
                               ),
                           ],

--- a/lib/inventory_page.dart
+++ b/lib/inventory_page.dart
@@ -307,6 +307,8 @@ class _InventoryListState extends State<InventoryList> {
                     },
                     child: InventoryCard(
                       inventory: inv,
+                      updateQuantity: _viewModel.updateQuantity,
+                      stocktake: _viewModel.stocktake,
                       onAddToList: () async {
                         await _viewModel.addToBuyList(inv);
                         if (mounted) {

--- a/lib/presentation/viewmodels/edit_category_viewmodel.dart
+++ b/lib/presentation/viewmodels/edit_category_viewmodel.dart
@@ -3,11 +3,12 @@ import 'package:flutter/material.dart' hide Category;
 
 import '../../domain/entities/category.dart';
 import '../../domain/usecases/update_category.dart';
+import '../../data/repositories/category_repository_impl.dart';
 
 /// カテゴリ編集画面の状態を管理する ViewModel
 class EditCategoryViewModel extends ChangeNotifier {
   /// カテゴリ更新ユースケース
-  final UpdateCategory _usecase;
+  final UpdateCategory _usecase = UpdateCategory(CategoryRepositoryImpl());
 
   /// フォームキー
   final GlobalKey<FormState> formKey = GlobalKey<FormState>();
@@ -33,7 +34,7 @@ class EditCategoryViewModel extends ChangeNotifier {
     Colors.cyan,
   ];
 
-  EditCategoryViewModel(this._usecase, this.original)
+  EditCategoryViewModel(this.original)
       : name = original.name,
         color = original.color != null
             ? Color(0xFF000000 | int.parse(original.color!.substring(1), radix: 16))

--- a/lib/presentation/viewmodels/home_page_viewmodel.dart
+++ b/lib/presentation/viewmodels/home_page_viewmodel.dart
@@ -9,6 +9,7 @@ import '../../domain/entities/category_order.dart';
 import '../../domain/entities/buy_list_condition_settings.dart';
 import '../../data/repositories/inventory_repository_impl.dart';
 import '../../domain/usecases/calculate_days_left.dart';
+import '../../domain/usecases/watch_inventory.dart';
 import '../../data/repositories/buy_list_repository_impl.dart';
 import '../../domain/usecases/add_buy_item.dart';
 import '../../data/repositories/buy_prediction_repository_impl.dart';
@@ -30,6 +31,7 @@ class HomePageViewModel extends ChangeNotifier {
 
   final CalculateDaysLeft _calcUsecase =
       CalculateDaysLeft(InventoryRepositoryImpl());
+  final WatchInventory _watchInventory = WatchInventory(InventoryRepositoryImpl());
   final AddBuyItem _addBuyItem = AddBuyItem(BuyListRepositoryImpl());
   final _predictionRepo = BuyPredictionRepositoryImpl();
   late final WatchPredictionItems watchPrediction =
@@ -39,6 +41,19 @@ class HomePageViewModel extends ChangeNotifier {
 
   /// 買い物リストへ商品を追加するユースケースを公開
   AddBuyItem get addBuyItem => _addBuyItem;
+
+  /// 予報アイテムを買い物リストへ追加
+  Future<void> addPredictionToBuyList(BuyItem item) async {
+    await _addBuyItem(item);
+  }
+
+  /// 予報アイテムを削除
+  Future<void> removePredictionItem(BuyItem item) async {
+    await removePrediction(item);
+  }
+
+  /// 在庫を監視
+  Stream<Inventory?> watchInventory(String id) => _watchInventory(id);
 
   /// 設定画面から戻った際などにカテゴリリストを更新する
   void updateCategories(List<Category> list) {

--- a/lib/presentation/viewmodels/inventory_list_viewmodel.dart
+++ b/lib/presentation/viewmodels/inventory_list_viewmodel.dart
@@ -6,6 +6,8 @@ import '../../domain/entities/buy_item.dart';
 import '../../domain/usecases/watch_inventories.dart';
 import '../../domain/usecases/delete_inventory.dart';
 import '../../domain/usecases/add_buy_item.dart';
+import '../../domain/usecases/update_quantity.dart';
+import '../../domain/usecases/stocktake.dart';
 import '../../data/repositories/inventory_repository_impl.dart';
 import '../../data/repositories/buy_list_repository_impl.dart';
 
@@ -19,6 +21,10 @@ class InventoryListViewModel extends ChangeNotifier {
   final DeleteInventory deleteUsecase =
       DeleteInventory(InventoryRepositoryImpl());
   final AddBuyItem addUsecase = AddBuyItem(BuyListRepositoryImpl());
+  final UpdateQuantity updateQuantityUsecase =
+      UpdateQuantity(InventoryRepositoryImpl());
+  final Stocktake stocktakeUsecase =
+      Stocktake(InventoryRepositoryImpl());
 
   /// 検索文字列
   String search = '';
@@ -49,6 +55,16 @@ class InventoryListViewModel extends ChangeNotifier {
   /// 在庫を買い物リストへ追加
   Future<void> addToBuyList(Inventory inv) async {
     await addUsecase(BuyItem(inv.itemName, inv.category, inv.id));
+  }
+
+  /// 在庫数量を更新
+  Future<void> updateQuantity(String id, double amount, String type) async {
+    await updateQuantityUsecase(id, amount, type);
+  }
+
+  /// 棚卸しを記録
+  Future<void> stocktake(String id, double before, double after, double diff) async {
+    await stocktakeUsecase(id, before, after, diff);
   }
 
   /// 在庫を削除

--- a/lib/presentation/viewmodels/sale_list_viewmodel.dart
+++ b/lib/presentation/viewmodels/sale_list_viewmodel.dart
@@ -47,6 +47,11 @@ class SaleListViewModel extends ChangeNotifier {
 
   final AddBuyItem addBuyItem = AddBuyItem(BuyListRepositoryImpl());
 
+  /// 買い物リストへ追加
+  Future<void> addToBuyList(SaleItem item) async {
+    await addBuyItem(BuyItem(item.name, ''));
+  }
+
   /// 並び替え後のリストを取得
   List<SaleItem> get sortedItems {
     final sorted = List<SaleItem>.from(items);

--- a/lib/sale_list_page.dart
+++ b/lib/sale_list_page.dart
@@ -78,7 +78,7 @@ class _SaleListPageState extends State<SaleListPage> {
                 final item = sorted[index];
                 return SaleItemCard(
                   item: item,
-                  addUsecase: _viewModel.addBuyItem,
+                  onAdd: _viewModel.addToBuyList,
                 );
               },
             ),

--- a/lib/widgets/inventory_card.dart
+++ b/lib/widgets/inventory_card.dart
@@ -2,15 +2,15 @@ import "package:flutter/material.dart";
 import "../i18n/app_localizations.dart";
 import "scrolling_text.dart"; // 長いテキストを流すウィジェット
 import "../domain/entities/inventory.dart";
-import "../domain/usecases/update_quantity.dart";
-import "../domain/usecases/stocktake.dart";
-import "../data/repositories/inventory_repository_impl.dart";
+
 // 在庫カードウィジェット
 // ホーム画面で1つの商品を表示し、数量操作などのボタンを提供する
 class InventoryCard extends StatelessWidget {
   final Inventory inventory;
-  final UpdateQuantity _update = UpdateQuantity(InventoryRepositoryImpl());
-  final Stocktake _stocktake = Stocktake(InventoryRepositoryImpl());
+  /// 数量更新コールバック
+  final Future<void> Function(String id, double amount, String type) updateQuantity;
+  /// 棚卸しコールバック
+  final Future<void> Function(String id, double before, double after, double diff) stocktake;
   final VoidCallback? onTap;
   // 購入ボタンのみ表示するかどうか
   final bool buyOnly;
@@ -20,6 +20,8 @@ class InventoryCard extends StatelessWidget {
   InventoryCard({
     super.key,
     required this.inventory,
+    required this.updateQuantity,
+    required this.stocktake,
     this.onTap,
     this.buyOnly = false,
     this.onAddToList,
@@ -82,7 +84,7 @@ class InventoryCard extends StatelessWidget {
     String type,
   ) async {
     try {
-      await _update(inventory.id, amount, type);
+      await updateQuantity(inventory.id, amount, type);
     } catch (e) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(AppLocalizations.of(context)!.updateFailed)),
@@ -119,7 +121,7 @@ class InventoryCard extends StatelessWidget {
     );
     if (v == null) return;
     try {
-      await _stocktake(inventory.id, inventory.quantity, v, v - inventory.quantity);
+      await stocktake(inventory.id, inventory.quantity, v, v - inventory.quantity);
     } catch (e) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(AppLocalizations.of(context)!.updateFailed)),

--- a/lib/widgets/sale_item_card.dart
+++ b/lib/widgets/sale_item_card.dart
@@ -1,6 +1,5 @@
 import "../i18n/app_localizations.dart";
 import 'package:flutter/material.dart';
-import '../domain/usecases/add_buy_item.dart';
 import '../domain/entities/buy_item.dart';
 import '../models/sale_item.dart';
 import '../util/localization_extensions.dart';
@@ -9,13 +8,13 @@ import '../util/localization_extensions.dart';
 class SaleItemCard extends StatelessWidget {
   /// 表示するセール情報
   final SaleItem item;
-  /// 買い物リスト追加ユースケース
-  final AddBuyItem addUsecase;
+  /// 買い物リストへ追加する処理
+  final Future<void> Function(BuyItem item) onAdd;
 
   const SaleItemCard({
     super.key,
     required this.item,
-    required this.addUsecase,
+    required this.onAdd,
   });
 
   @override
@@ -70,7 +69,7 @@ class SaleItemCard extends StatelessWidget {
               alignment: Alignment.centerRight,
               child: ElevatedButton(
                 onPressed: () async {
-                  await addUsecase(BuyItem(item.name, ''));
+                  await onAdd(BuyItem(item.name, ''));
                   if (context.mounted) {
                     ScaffoldMessenger.of(context).showSnackBar(
                       SnackBar(content: Text(loc.addedBuyItem)),

--- a/test/buy_list_page_test.dart
+++ b/test/buy_list_page_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:oouchi_stock/buy_list_page.dart';
 import 'package:oouchi_stock/widgets/buy_list_card.dart';
 import 'package:oouchi_stock/domain/entities/category.dart';
+import 'package:oouchi_stock/presentation/viewmodels/buy_list_viewmodel.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:oouchi_stock/domain/entities/history_entry.dart';
 import 'package:oouchi_stock/domain/entities/inventory.dart';
@@ -85,7 +86,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       home: BuyListPage(
         categories: categories,
-        repository: _FakeRepository(),
+        viewModel: BuyListViewModel(repository: _FakeRepository()),
       ),
     ));
     await tester.pumpAndSettle();
@@ -101,7 +102,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       home: BuyListPage(
         categories: categories,
-        repository: _FakeRepository(),
+        viewModel: BuyListViewModel(repository: _FakeRepository()),
       ),
     ));
     await tester.pumpAndSettle();

--- a/test/inventory_card_test.dart
+++ b/test/inventory_card_test.dart
@@ -15,8 +15,12 @@ void main() {
       monthlyConsumption: 0,
       createdAt: DateTime.now(),
     );
-    await tester
-        .pumpWidget(MaterialApp(home: InventoryCard(inventory: inv)));
+    await tester.pumpWidget(MaterialApp(
+        home: InventoryCard(
+      inventory: inv,
+      updateQuantity: (_, __, ___) async {},
+      stocktake: (_, __, ___, ____) async {},
+    )));
     expect(find.textContaining('ティッシュ'), findsOneWidget);
   });
 
@@ -32,8 +36,13 @@ void main() {
       monthlyConsumption: 0,
       createdAt: DateTime.now(),
     );
-    await tester
-        .pumpWidget(MaterialApp(home: InventoryCard(inventory: inv, buyOnly: true)));
+    await tester.pumpWidget(MaterialApp(
+        home: InventoryCard(
+      inventory: inv,
+      updateQuantity: (_, __, ___) async {},
+      stocktake: (_, __, ___, ____) async {},
+      buyOnly: true,
+    )));
     expect(find.byType(IconButton), findsOneWidget);
   });
 
@@ -48,7 +57,12 @@ void main() {
       monthlyConsumption: 0,
       createdAt: DateTime.now(),
     );
-    await tester.pumpWidget(MaterialApp(home: InventoryCard(inventory: inv)));
+    await tester.pumpWidget(MaterialApp(
+        home: InventoryCard(
+      inventory: inv,
+      updateQuantity: (_, __, ___) async {},
+      stocktake: (_, __, ___, ____) async {},
+    )));
     expect(find.byType(SingleChildScrollView), findsOneWidget);
   });
 }

--- a/test/prediction_card_test.dart
+++ b/test/prediction_card_test.dart
@@ -6,10 +6,6 @@ import 'package:oouchi_stock/domain/entities/category.dart';
 import 'package:oouchi_stock/domain/entities/inventory.dart';
 import 'package:oouchi_stock/domain/entities/history_entry.dart';
 import 'package:oouchi_stock/domain/repositories/inventory_repository.dart';
-import 'package:oouchi_stock/domain/repositories/buy_list_repository.dart';
-import 'package:oouchi_stock/domain/repositories/buy_prediction_repository.dart';
-import 'package:oouchi_stock/domain/usecases/add_buy_item.dart';
-import 'package:oouchi_stock/domain/usecases/remove_prediction_item.dart';
 
 class _FakeInventoryRepository implements InventoryRepository {
   @override
@@ -45,23 +41,6 @@ class _FakeInventoryRepository implements InventoryRepository {
   Stream<List<HistoryEntry>> watchHistory(String inventoryId) => const Stream.empty();
 }
 
-class _DummyBuyListRepo implements BuyListRepository {
-  @override
-  Stream<List<BuyItem>> watchItems() => const Stream.empty();
-  @override
-  Future<void> addItem(BuyItem item) async {}
-  @override
-  Future<void> removeItem(BuyItem item) async {}
-}
-
-class _DummyPredictionRepo implements BuyPredictionRepository {
-  @override
-  Stream<List<BuyItem>> watchItems() => const Stream.empty();
-  @override
-  Future<void> addItem(BuyItem item) async {}
-  @override
-  Future<void> removeItem(BuyItem item) async {}
-}
 
 void main() {
   testWidgets('PredictionCard 表示テスト', (WidgetTester tester) async {
@@ -71,9 +50,9 @@ void main() {
       home: PredictionCard(
         item: item,
         categories: categories,
-        repository: _FakeInventoryRepository(),
-        addUsecase: AddBuyItem(_DummyBuyListRepo()),
-        removeUsecase: RemovePredictionItem(_DummyPredictionRepo()),
+        watchInventory: _FakeInventoryRepository().watchInventory,
+        addToBuyList: (_) async {},
+        removePrediction: (_) async {},
         calcDaysLeft: (_) async => 7,
       ),
     ));


### PR DESCRIPTION
## Summary
- Widget内でUseCaseやRepositoryを利用しないようリファクタリング
- ViewModelに依存関係を集約し、コールバックをWidgetへ渡す構造に変更
- テストコードを新しい構造に合わせ更新
- 取扱説明書にViewModel経由で処理する方針を追記

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685abb81161c832eb3b5798df194113f