### PR TITLE
Remove usecase reference from PriceListPage

### DIFF
--- a/lib/price_list_page.dart
+++ b/lib/price_list_page.dart
@@ -9,7 +9,6 @@ import 'price_detail_page.dart';
 import 'main.dart';
 import 'widgets/scrolling_text.dart';
 import 'domain/entities/price_info.dart';
-import 'domain/usecases/watch_price_by_category.dart';
 
 /// セール情報管理画面
 class PriceListPage extends StatefulWidget {
@@ -113,22 +112,28 @@ class _PriceListPageState extends State<PriceListPage> {
 
 /// カテゴリ別セール一覧ウィジェット
 class PriceCategoryList extends StatefulWidget {
+  /// 表示対象のカテゴリ名
   final String category;
-  final WatchPriceByCategory? watch;
-  const PriceCategoryList({super.key, required this.category, this.watch});
+
+  /// テスト用に注入する ViewModel (通常は null)
+  final PriceCategoryListViewModel? viewModel;
+
+  const PriceCategoryList({super.key, required this.category, this.viewModel});
 
   @override
   State<PriceCategoryList> createState() => _PriceCategoryListState();
 }
 
 class _PriceCategoryListState extends State<PriceCategoryList> {
+  /// カテゴリリストを管理する ViewModel
   late final PriceCategoryListViewModel _viewModel;
 
   @override
   void initState() {
     super.initState();
-    _viewModel = PriceCategoryListViewModel(category: widget.category, watch: widget.watch)
-      ..addListener(() { if (mounted) setState(() {}); });
+    _viewModel = widget.viewModel ??
+        PriceCategoryListViewModel(category: widget.category);
+    _viewModel.addListener(() { if (mounted) setState(() {}); });
   }
 
   @override

--- a/test/price_list_page_test.dart
+++ b/test/price_list_page_test.dart
@@ -5,6 +5,7 @@ import 'package:oouchi_stock/price_detail_page.dart';
 import 'package:oouchi_stock/domain/entities/price_info.dart';
 import 'package:oouchi_stock/domain/repositories/price_repository.dart';
 import 'package:oouchi_stock/domain/usecases/watch_price_by_category.dart';
+import 'package:oouchi_stock/presentation/viewmodels/price_category_list_viewmodel.dart';
 
 void main() {
   testWidgets('カテゴリがない場合はメッセージと追加ボタンを表示', (WidgetTester tester) async {
@@ -26,7 +27,10 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       home: PriceCategoryList(
         category: '日用品',
-        watch: WatchPriceByCategory(repo),
+        viewModel: PriceCategoryListViewModel(
+          category: '日用品',
+          watch: WatchPriceByCategory(repo),
+        ),
       ),
     ));
     await tester.pump();
@@ -39,7 +43,10 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       home: PriceCategoryList(
         category: '日用品',
-        watch: WatchPriceByCategory(repo),
+        viewModel: PriceCategoryListViewModel(
+          category: '日用品',
+          watch: WatchPriceByCategory(repo),
+        ),
       ),
     ));
     await tester.pump();
@@ -51,7 +58,10 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       home: PriceCategoryList(
         category: '日用品',
-        watch: WatchPriceByCategory(repo),
+        viewModel: PriceCategoryListViewModel(
+          category: '日用品',
+          watch: WatchPriceByCategory(repo),
+        ),
       ),
     ));
     await tester.pump();


### PR DESCRIPTION
## Summary
- PriceListPageからWatchPriceByCategoryの参照を削除
- PriceCategoryListにViewModel注入機能を追加
- テストをViewModel注入方式に対応

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685ac03e90fc832e9f665423b9b6c5c7