### PR TITLE
広告初期化時の例外処理追加

### DIFF
--- a/docs/user_manual_ja.md
+++ b/docs/user_manual_ja.md
@@ -6,6 +6,7 @@
 なお、広告表示機能には `google_mobile_ads` パッケージのバージョン 4.0.0 以上が必要です。
 また、動作させるには AndroidManifest と iOS の Info.plist にそれぞれ有効な AdMob の
 App ID を設定しておく必要があります。テスト用途であればサンプル ID を利用できます。
+WebView が無効、またはインストールされていない端末では広告初期化時にエラーログが表示されます。広告機能を利用するには Android System WebView もしくは Chrome を有効にしてください。
 また、AndroidManifest.xml を編集する際は XML 形式を崩さないよう注意し、コメントはタグの外側に記述してください。
 
 ## ログイン

--- a/lib/presentation/viewmodels/main_viewmodel.dart
+++ b/lib/presentation/viewmodels/main_viewmodel.dart
@@ -37,7 +37,14 @@ class MainViewModel extends ChangeNotifier {
   Future<void> init() async {
     WidgetsFlutterBinding.ensureInitialized();
     await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
-    await MobileAds.instance.initialize();
+    try {
+      // Google Mobile Ads SDK の初期化
+      // ホーム画面で広告を表示するため、アプリ起動時に実行する
+      await MobileAds.instance.initialize();
+    } catch (e, s) {
+      // WebView が無効などの理由で初期化に失敗してもアプリが落ちないようログのみ出力
+      debugPrint('MobileAds initialize failed: $e\n$s');
+    }
     final systemLocale = WidgetsBinding.instance.platformDispatcher.locale;
     FirebaseAuth.instance.setLanguageCode(systemLocale.languageCode);
     FirebaseFirestore.instance.settings = const Settings(persistenceEnabled: true);


### PR DESCRIPTION
## Summary
- MobileAds 初期化処理を try-catch で囲み、失敗時にログ出力のみ行うよう変更
- ユーザー向けマニュアルに WebView が無効な場合の注意点を追記

## Testing
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bfdb8cde4832e9243364dc115aba8