### PR TITLE
Fix window-sidecar version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Android ビルドを行う場合は JDK 17 が必要です。`JAVA_HOME` が JDK
 ることを確認してください。
 
 折りたたみ端末などの最新機種に対応するため、AndroidX Window ライブラリを利用しています。
-Flutter エンジンと互換性のある `1.1.x` 系を使用しており、`android/app/build.gradle.kts` では `1.1.0` を指定しています。
+Flutter エンジンと互換性のある `1.0.x` 系を使用しており、`android/app/build.gradle.kts` では `1.0.0` を指定しています。
 一部の端末ではサイドカー API が読み込めず `NoClassDefFoundError` が出るため、
-`androidx.window:window-sidecar` も依存関係に追加しています。
+`androidx.window:window-sidecar` も依存関係に追加しています。取得可能な最新バージョンは `0.1.0` のため、これを指定しています。
 ビルド時にエラーが発生する場合は `androidx.window:window` と `window-sidecar`
 が正しいバージョンで取得できているか確認してください。
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -68,7 +68,9 @@ dependencies {
     // 折りたたみ端末向けサイドカー API のクラスが読み込めず
     // NoClassDefFoundError が発生することへの対策として sidecar 依存も追加
     // ログイン画面やホーム画面を表示する際に FlutterView が参照する
-    implementation("androidx.window:window-sidecar:1.1.0")
+    // 現在入手可能な最新のサイドカー API ライブラリは 0.1.0 のため
+    // 1.1.0 では取得に失敗しビルドエラーとなるためバージョンを修正
+    implementation("androidx.window:window-sidecar:0.1.0")
     // Desugaring library required when using Java 8+ APIs on lower API levels
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
 }


### PR DESCRIPTION
## Summary
- AndroidX Window Sidecar のバージョンを 0.1.0 に修正
- README を最新の依存バージョンに更新

## Testing
- `flutter test` *(failed: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c0321a06c832ebcf671aaf7a62db8