### PR TITLE
Fix WatchPriceByType import in PriceHistoryPage

### DIFF
--- a/lib/price_history_page.dart
+++ b/lib/price_history_page.dart
@@ -1,13 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:oouchi_stock/i18n/app_localizations.dart';
 import 'presentation/viewmodels/price_history_viewmodel.dart';
+import 'domain/usecases/watch_price_by_type.dart';
+import 'domain/usecases/delete_price_info.dart';
 
 /// セール情報履歴画面
 class PriceHistoryPage extends StatefulWidget {
+  /// カテゴリ名
   final String category;
+  /// 品種名
   final String itemType;
+  /// 画面タイトルに表示する商品名
   final String? itemName;
+  /// セール情報を監視するユースケース
   final WatchPriceByType? watch;
+  /// セール情報を削除するユースケース
   final DeletePriceInfo? deleter;
   const PriceHistoryPage({
     super.key,
@@ -23,6 +30,7 @@ class PriceHistoryPage extends StatefulWidget {
 }
 
 class _PriceHistoryPageState extends State<PriceHistoryPage> {
+  /// 画面の状態を管理する ViewModel
   late final PriceHistoryViewModel _viewModel;
 
   @override
@@ -59,6 +67,7 @@ class _PriceHistoryPageState extends State<PriceHistoryPage> {
                 Card(
                   margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
                   child: InkWell(
+                    // セール情報カードを長押ししたときに削除メニューを表示
                     onLongPress: () async {
                       final res = await showModalBottomSheet<String>(
                         context: context,
@@ -71,6 +80,7 @@ class _PriceHistoryPageState extends State<PriceHistoryPage> {
                         ),
                       );
                       if (res == 'delete') {
+                        // 選択した履歴を削除
                         await _viewModel.delete(p.id);
                       }
                     },
@@ -105,8 +115,10 @@ class _PriceHistoryPageState extends State<PriceHistoryPage> {
     );
   }
 
+  /// 日付を YYYY/M/D 形式の文字列に変換
   String _formatDate(DateTime d) => '${d.year}/${d.month}/${d.day}';
 
+  /// ラベルと値を横並びで表示する行ウィジェットを作成
   Widget _buildRow(String label, String value, [TextStyle? style]) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),


### PR DESCRIPTION
## Summary
- インポート漏れにより発生していた `WatchPriceByType` 未定義エラーを修正
- セール情報履歴画面の各プロパティや削除操作に日本語コメントを追加

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c03497e98832ea171bb7758d40ffc