### PR TITLE
在庫追加画面の警告解消

### DIFF
--- a/lib/add_inventory_page.dart
+++ b/lib/add_inventory_page.dart
@@ -182,45 +182,43 @@ class _AddInventoryPageState extends State<AddInventoryPage> {
                 onPressed: () async {
                   // フォームの入力が正しいか確認
                   if (_viewModel.formKey.currentState!.validate()) {
+                    // build メソッドの context を保持
+                    final ctx = context;
                     try {
                       await _viewModel.save();
-                      if (!mounted) return;
-                      final snackBar = ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(content: Text(AppLocalizations.of(context)!.saved)),
+                      if (!ctx.mounted) return;
+                      final snackBar = ScaffoldMessenger.of(ctx).showSnackBar(
+                        SnackBar(content: Text(AppLocalizations.of(ctx)!.saved)),
                       );
                       await snackBar.closed;
-                      if (!mounted) return;
+                      if (!ctx.mounted) return;
                       // 画面がスタックに積まれている場合のみ前の画面へ戻る
-                      if (Navigator.of(context).canPop()) {
-                        Navigator.pop(context);
+                      if (Navigator.of(ctx).canPop()) {
+                        Navigator.pop(ctx);
                       } else {
                         // ルート画面から商品追加した場合はフォームをリセットする
                         setState(() {
                           _viewModel.formKey.currentState?.reset();
-                          _viewModel.setItemName('');
-                          _viewModel.setNote('');
-                          _viewModel.quantity = 1.0;
-                          _viewModel.volume = 1.0;
-                          _viewModel.notifyListeners();
+                          _viewModel.resetFields();
                         });
                       }
                     } on FirebaseException catch (e) {
                       // Firestore からの例外をログに出力
                       debugPrint('在庫保存失敗: ${e.message ?? e.code}');
-                      if (mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
+                      if (ctx.mounted) {
+                        ScaffoldMessenger.of(ctx).showSnackBar(
                           SnackBar(
                             content: Text(
-                                '${AppLocalizations.of(context)!.saveFailed}: ${e.message ?? e.code}'),
+                                '${AppLocalizations.of(ctx)!.saveFailed}: ${e.message ?? e.code}'),
                           ),
                         );
                       }
                     } catch (e) {
                       // その他の例外をログに出力
                       debugPrint('在庫保存失敗: $e');
-                      if (mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(content: Text(AppLocalizations.of(context)!.saveFailed)),
+                      if (ctx.mounted) {
+                        ScaffoldMessenger.of(ctx).showSnackBar(
+                          SnackBar(content: Text(AppLocalizations.of(ctx)!.saveFailed)),
                         );
                       }
                     }

--- a/lib/presentation/viewmodels/add_inventory_viewmodel.dart
+++ b/lib/presentation/viewmodels/add_inventory_viewmodel.dart
@@ -150,6 +150,15 @@ class AddInventoryViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// 入力フォームの内容を初期化
+  void resetFields() {
+    itemName = '';
+    note = '';
+    quantity = 1.0;
+    volume = 1.0;
+    notifyListeners();
+  }
+
   /// メモ設定処理
   void setNote(String v) {
     note = v;


### PR DESCRIPTION
## 変更内容
- AddInventoryViewModel にフォームを初期化する `resetFields` を追加
- AddInventoryPage で BuildContext を保持して非同期処理後の警告を解消
- 保存ボタンのフォームリセット処理を `resetFields` 呼び出しに変更

## テスト
- `flutter test` を実行しましたが、環境に flutter が無いため失敗しました

------
https://chatgpt.com/codex/tasks/task_e_685c039020ec832e8adf920e824bc57f