### PR TITLE
notifyListeners呼び出しの修正

### DIFF
--- a/lib/add_inventory_page.dart
+++ b/lib/add_inventory_page.dart
@@ -197,11 +197,7 @@ class _AddInventoryPageState extends State<AddInventoryPage> {
                         // ルート画面から商品追加した場合はフォームをリセットする
                         setState(() {
                           _viewModel.formKey.currentState?.reset();
-                          _viewModel.setItemName('');
-                          _viewModel.setNote('');
-                          _viewModel.quantity = 1.0;
-                          _viewModel.volume = 1.0;
-                          _viewModel.notifyListeners();
+                          _viewModel.resetForm();
                         });
                       }
                     } on FirebaseException catch (e) {

--- a/lib/presentation/viewmodels/add_inventory_viewmodel.dart
+++ b/lib/presentation/viewmodels/add_inventory_viewmodel.dart
@@ -160,6 +160,17 @@ class AddInventoryViewModel extends ChangeNotifier {
     itemName = v;
   }
 
+  /// フォームを初期状態に戻す処理
+  ///
+  /// 商品追加画面で保存後に入力内容をクリアするために使用する
+  void resetForm() {
+    itemName = '';
+    note = '';
+    quantity = 1.0;
+    volume = 1.0;
+    notifyListeners();
+  }
+
   /// 在庫保存
   Future<void> save() async {
     final item = Inventory(


### PR DESCRIPTION
## 概要
- AddInventoryViewModel にフォームリセット処理を追加
- AddInventoryPage から notifyListeners への直接アクセスを廃止

## テスト
- `flutter test` 実行 (flutter コマンドが見つからず実行できず)


------
https://chatgpt.com/codex/tasks/task_e_685c03a14ca0832eb627135f03dfae13