### PR TITLE
PriceHistoryPageのViewModel注入対応

### DIFF
--- a/docs/architecture_proposals_ja.md
+++ b/docs/architecture_proposals_ja.md
@@ -26,6 +26,7 @@
   さらに在庫一覧画面でも `InventoryPageViewModel` と `InventoryListViewModel` を導入し、
   画面の状態遷移を ViewModel に集約しました。
  買い物予報画面も `BuyListViewModel` を用いてロジックを分離しています。
+ セール情報履歴画面も `PriceHistoryViewModel` を導入し、一覧取得と削除処理を ViewModel に集約しました。
   また、アプリ起動時の初期化処理は `MainViewModel` にまとめ、
   `main.dart` は ViewModel を利用するだけの形に変更しました。
 

--- a/lib/price_history_page.dart
+++ b/lib/price_history_page.dart
@@ -4,11 +4,19 @@ import 'presentation/viewmodels/price_history_viewmodel.dart';
 
 /// セール情報履歴画面
 class PriceHistoryPage extends StatefulWidget {
+  /// 表示するカテゴリ名
   final String category;
+  /// 表示する品種名
   final String itemType;
+  /// 任意の商品名。指定がない場合は品種名をタイトルに使用
   final String? itemName;
+  /// Firestore 監視ユースケース（テスト用）
   final WatchPriceByType? watch;
+  /// 削除ユースケース（テスト用）
   final DeletePriceInfo? deleter;
+  /// 外部から注入する ViewModel（テスト用）
+  final PriceHistoryViewModel? viewModel;
+
   const PriceHistoryPage({
     super.key,
     required this.category,
@@ -16,6 +24,7 @@ class PriceHistoryPage extends StatefulWidget {
     this.itemName,
     this.watch,
     this.deleter,
+    this.viewModel,
   });
 
   @override
@@ -23,17 +32,20 @@ class PriceHistoryPage extends StatefulWidget {
 }
 
 class _PriceHistoryPageState extends State<PriceHistoryPage> {
+  /// 画面の状態を管理する ViewModel
   late final PriceHistoryViewModel _viewModel;
 
   @override
   void initState() {
     super.initState();
-    _viewModel = PriceHistoryViewModel(
-      category: widget.category,
-      itemType: widget.itemType,
-      watch: widget.watch,
-      deleter: widget.deleter,
-    );
+    // 指定があれば外部提供の ViewModel を利用し、なければ新規作成
+    _viewModel = widget.viewModel ??
+        PriceHistoryViewModel(
+          category: widget.category,
+          itemType: widget.itemType,
+          watch: widget.watch,
+          deleter: widget.deleter,
+        );
   }
 
   @override
@@ -59,6 +71,7 @@ class _PriceHistoryPageState extends State<PriceHistoryPage> {
                 Card(
                   margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
                   child: InkWell(
+                    // 履歴カードを長押しした際の削除メニュー表示
                     onLongPress: () async {
                       final res = await showModalBottomSheet<String>(
                         context: context,
@@ -105,8 +118,10 @@ class _PriceHistoryPageState extends State<PriceHistoryPage> {
     );
   }
 
+  /// 日付を YYYY/M/D 形式に整形
   String _formatDate(DateTime d) => '${d.year}/${d.month}/${d.day}';
 
+  /// ラベルと値を左右に並べて表示する共通行ウィジェット
   Widget _buildRow(String label, String value, [TextStyle? style]) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),

--- a/test/price_history_page_test.dart
+++ b/test/price_history_page_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:oouchi_stock/price_history_page.dart';
+import 'package:oouchi_stock/presentation/viewmodels/price_history_viewmodel.dart';
 import 'package:oouchi_stock/domain/entities/price_info.dart';
 import 'package:oouchi_stock/domain/repositories/price_repository.dart';
 import 'package:oouchi_stock/domain/usecases/delete_price_info.dart';
@@ -31,6 +32,39 @@ void main() {
     await tester.pump();
     final text = tester.widget<Text>(find.text('テスト商品'));
     expect(text.style?.fontSize, 18);
+  });
+
+  testWidgets('外部 ViewModel を注入できる', (WidgetTester tester) async {
+    final vm = _FakeViewModel(Stream.value([
+      PriceInfo(
+        id: '1',
+        inventoryId: '1',
+        checkedAt: DateTime(2023, 1, 1),
+        category: 'c',
+        itemType: 't',
+        itemName: 'テスト商品',
+        count: 1,
+        unit: '個',
+        volume: 1,
+        totalVolume: 1,
+        regularPrice: 200,
+        salePrice: 150,
+        shop: '店',
+        approvalUrl: '',
+        memo: '',
+        unitPrice: 150,
+        expiry: DateTime(2023, 1, 2),
+      )
+    ]));
+    await tester.pumpWidget(MaterialApp(
+      home: PriceHistoryPage(
+        category: 'c',
+        itemType: 't',
+        viewModel: vm,
+      ),
+    ));
+    await tester.pump();
+    expect(find.text('テスト商品'), findsOneWidget);
   });
 }
 
@@ -67,4 +101,13 @@ class _FakeRepository implements PriceRepository {
 
   @override
   Future<void> deletePriceInfo(String id) async {}
+}
+
+class _FakeViewModel extends PriceHistoryViewModel {
+  final Stream<List<PriceInfo>> _stream;
+  _FakeViewModel(this._stream)
+      : super(category: 'c', itemType: 't', watch: WatchPriceByType(_FakeRepository()), deleter: DeletePriceInfo(_FakeRepository()));
+
+  @override
+  Stream<List<PriceInfo>> stream() => _stream;
 }


### PR DESCRIPTION
## 概要
- PriceHistoryPage に ViewModel を外部から注入できるよう変更
- ViewModel 注入テスト追加
- アーキテクチャドキュメントに PriceHistoryViewModel 追記

## テスト
- `flutter test` (実行不可: `flutter` コマンド未インストール)

------
https://chatgpt.com/codex/tasks/task_e_685c044cbfd4832e9b90ad76faeb68a7