### PR TITLE
AndroidX Window Sidecar バージョン更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Android ビルドを行う場合は JDK 17 が必要です。`JAVA_HOME` が JDK
 折りたたみ端末などの最新機種に対応するため、AndroidX Window ライブラリを利用しています。
 Flutter エンジンと互換性のある `1.0.x` 系を使用しており、`android/app/build.gradle.kts` では `1.0.0` を指定しています。
 一部の端末ではサイドカー API が読み込めず `NoClassDefFoundError` が出るため、
-`androidx.window:window-sidecar` も依存関係に追加しています。取得可能な最新バージョンは `0.1.0` のため、これを指定しています。
+`androidx.window:window-sidecar` も依存関係に追加しています。取得可能な最新バージョンは `0.1.1` のため、これを指定しています。
 ビルド時にエラーが発生する場合は `androidx.window:window` と `window-sidecar`
 が正しいバージョンで取得できているか確認してください。
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -68,9 +68,9 @@ dependencies {
     // 折りたたみ端末向けサイドカー API のクラスが読み込めず
     // NoClassDefFoundError が発生することへの対策として sidecar 依存も追加
     // ログイン画面やホーム画面を表示する際に FlutterView が参照する
-    // 現在入手可能な最新のサイドカー API ライブラリは 0.1.0 のため
-    // 1.1.0 では取得に失敗しビルドエラーとなるためバージョンを修正
-    implementation("androidx.window:window-sidecar:0.1.0")
+    // 現在入手可能な最新のサイドカー API ライブラリは 0.1.1 のため
+    // 0.1.0 ではリポジトリから取得できずビルドエラーとなるためバージョンを更新
+    implementation("androidx.window:window-sidecar:0.1.1")
     // Desugaring library required when using Java 8+ APIs on lower API levels
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
 }


### PR DESCRIPTION
## 概要
- `androidx.window:window-sidecar` を 0.1.1 に更新
- README を更新

## テスト結果
- `flutter test` 実行を試みましたが、環境に Flutter が存在せず実行できませんでした。
Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.


------
https://chatgpt.com/codex/tasks/task_e_685c058bdd04832ea2d11c814c38b91e