### PR TITLE
Fix buy list not reloading after inventory page

### DIFF
--- a/lib/data/repositories/buy_list_repository_impl.dart
+++ b/lib/data/repositories/buy_list_repository_impl.dart
@@ -5,10 +5,15 @@ import '../../domain/repositories/buy_list_repository.dart';
 
 /// SharedPreferences を用いて買い物リストを保存するリポジトリ実装
 class BuyListRepositoryImpl implements BuyListRepository {
+  // SharedPreferences に保存する際のキー
   static const _key = 'buy_list_items';
+  // リスト更新通知用のストリームコントローラ
   final StreamController<List<BuyItem>> _controller =
       StreamController<List<BuyItem>>.broadcast();
+  // 初期化済みかどうか
   bool _initialized = false;
+  // 現在の買い物リストを保持する
+  List<BuyItem> _items = [];
 
   /// SharedPreferences の取得
   Future<SharedPreferences> get _prefs async =>
@@ -19,15 +24,16 @@ class BuyListRepositoryImpl implements BuyListRepository {
     if (_initialized) return;
     final prefs = await _prefs;
     final items = prefs.getStringList(_key) ?? [];
-    _controller.add(items.map(BuyItem.fromKey).toList());
+    _items = items.map(BuyItem.fromKey).toList();
     _initialized = true;
   }
 
   @override
   /// 買い物リストの変更を監視する
-  Stream<List<BuyItem>> watchItems() {
-    _init();
-    return _controller.stream;
+  Stream<List<BuyItem>> watchItems() async* {
+    await _init();
+    yield List<BuyItem>.from(_items);
+    yield* _controller.stream;
   }
 
   @override
@@ -39,7 +45,8 @@ class BuyListRepositoryImpl implements BuyListRepository {
     if (!list.contains(item.key)) {
       list.add(item.key);
       await prefs.setStringList(_key, list);
-      _controller.add(list.map(BuyItem.fromKey).toList());
+      _items = list.map(BuyItem.fromKey).toList();
+      _controller.add(List<BuyItem>.from(_items));
     }
   }
 
@@ -51,6 +58,7 @@ class BuyListRepositoryImpl implements BuyListRepository {
     final list = prefs.getStringList(_key) ?? [];
     list.remove(item.key);
     await prefs.setStringList(_key, list);
-    _controller.add(list.map(BuyItem.fromKey).toList());
+    _items = list.map(BuyItem.fromKey).toList();
+    _controller.add(List<BuyItem>.from(_items));
   }
 }


### PR DESCRIPTION
## Summary
- fix buy list repository to resend current items on new subscription

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fd9149868832e80530a4b8d3b20b4