### PR TITLE
SaleListViewModelからサンプルデータ削除

### DIFF
--- a/lib/presentation/viewmodels/sale_list_viewmodel.dart
+++ b/lib/presentation/viewmodels/sale_list_viewmodel.dart
@@ -6,38 +6,8 @@ import '../../models/sale_item.dart';
 
 /// 買い得リスト画面の状態を管理する ViewModel
 class SaleListViewModel extends ChangeNotifier {
-  /// 表示するセール情報一覧
-  final List<SaleItem> items = [
-    SaleItem(
-      name: 'コーヒー豆 200g',
-      shop: 'Amazon',
-      regularPrice: 1200,
-      salePrice: 980,
-      start: DateTime.now().subtract(const Duration(days: 1)),
-      end: DateTime.now().add(const Duration(days: 2)),
-      stock: 5,
-      recommended: true,
-      lowest: true,
-    ),
-    SaleItem(
-      name: 'トイレットペーパー 12ロール',
-      shop: '楽天',
-      regularPrice: 600,
-      salePrice: 480,
-      start: DateTime.now(),
-      end: DateTime.now().add(const Duration(days: 5)),
-      stock: 20,
-    ),
-    SaleItem(
-      name: '洗剤 詰め替え用',
-      shop: '近所のスーパー',
-      regularPrice: 350,
-      salePrice: 300,
-      start: DateTime.now().subtract(const Duration(days: 2)),
-      end: DateTime.now().add(const Duration(days: 1)),
-      stock: 1,
-    ),
-  ];
+  /// 表示するセール情報一覧（現在は未使用のため空リスト）
+  final List<SaleItem> items = [];
 
   /// 通知オン/オフ
   bool notify = true;

--- a/test/sale_list_page_test.dart
+++ b/test/sale_list_page_test.dart
@@ -4,9 +4,11 @@ import 'package:oouchi_stock/sale_list_page.dart';
 import 'package:oouchi_stock/widgets/sale_item_card.dart';
 
 void main() {
+  // セール情報一覧画面を開いた直後の表示をテストする
   testWidgets('SaleListPage 初期表示', (WidgetTester tester) async {
     await tester.pumpWidget(const MaterialApp(home: SaleListPage()));
     expect(find.byType(AppBar), findsOneWidget);
-    expect(find.byType(SaleItemCard), findsWidgets);
+    // サンプルデータ削除に伴いカードは表示されない
+    expect(find.byType(SaleItemCard), findsNothing);
   });
 }


### PR DESCRIPTION
## 概要
- SaleListViewModelのダミーSaleItemリストを削除
- SaleListPageのテストをサンプルデータ無しの状態に更新

## 動作確認
- `flutter test` は実行環境にFlutterがないため失敗


------
https://chatgpt.com/codex/tasks/task_e_6868ca88775c832ea526e3252635a1e0