### PR TITLE
「総容量」表記への変更

### DIFF
--- a/lib/i18n/app_en.arb
+++ b/lib/i18n/app_en.arb
@@ -79,7 +79,7 @@
   "checkedDate": "Checked: {date}",
   "categorySettings": "Category Settings",
   "priceSummary": "Count:{count} {unit} Total volume:{volume} Total:{total} Price:{price} Store:{shop} Unit price:{unitPrice}",
-  "totalVolumeLabel": "Total",
+  "totalVolumeLabel": "Total Volume",
   "unitPriceLabel": "Unit price",
   "sortUnitPrice": "Low unit price",
   "inventoryList": "Inventory List",

--- a/lib/i18n/app_ja.arb
+++ b/lib/i18n/app_ja.arb
@@ -79,7 +79,7 @@
   "checkedDate": "確認日: {date}",
   "categorySettings": "カテゴリ設定",
   "priceSummary": "数:{count} {unit} 合計容量:{volume} 合計:{total} 値段:{price} 購入店舗:{shop} 単価:{unitPrice}",
-  "totalVolumeLabel": "合計",
+  "totalVolumeLabel": "総容量",
   "unitPriceLabel": "単価",
   "sortUnitPrice": "単価安い順",
   "inventoryList": "在庫一覧",


### PR DESCRIPTION
## 概要
- セール詳細情報画面と商品詳細画面で表示されるラベルを「合計」から「総容量」へ変更しました
- 日本語・英語両方の翻訳ファイルを更新

## テスト結果
- `flutter test` を実行しようとしましたが、環境に Flutter が存在しないためテストを実行できませんでした

------
https://chatgpt.com/codex/tasks/task_e_68723badded0832e9d696db7f68211eb