### PR TITLE
Fix category settings parentheses issue

### DIFF
--- a/lib/category_settings_page.dart
+++ b/lib/category_settings_page.dart
@@ -126,6 +126,7 @@ class _CategorySettingsPageState extends State<CategorySettingsPage> {
                 );
                 return res ?? false;
               },
+              // スワイプでカテゴリを削除する
               onDismissed: (_) => _deleteCategory(c),
               background: Container(
                 color: Colors.red,
@@ -142,7 +143,7 @@ class _CategorySettingsPageState extends State<CategorySettingsPage> {
                       decoration: BoxDecoration(
                         color: Color(
                           int.parse(
-                            'ff${c.color!.replaceFirst('#', '')}',
+                            "ff${c.color!.replaceFirst('#', '')}",
                             radix: 16,
                           ),
                         ),
@@ -150,6 +151,7 @@ class _CategorySettingsPageState extends State<CategorySettingsPage> {
                       ),
                     ),
               title: Text(c.name),
+              // カテゴリをタップしたときに編集画面へ遷移
               onTap: () async {
                 await Navigator.push<String>(
                   context,
@@ -164,6 +166,7 @@ class _CategorySettingsPageState extends State<CategorySettingsPage> {
       floatingActionButton: FloatingActionButton(
         // カテゴリ設定画面専用のヒーロータグ
         heroTag: 'categoryFab',
+        // 追加ボタン押下時にカテゴリ追加画面を表示
         onPressed: () async {
           await Navigator.push(
             context,

--- a/lib/price_list_page.dart
+++ b/lib/price_list_page.dart
@@ -96,8 +96,9 @@ class _PriceListPageState extends State<PriceListPage> {
             for (final c in _viewModel.categories) PriceCategoryList(category: c.name)
           ],
         ),
-        floatingActionButton: FloatingActionButton(
-          heroTag: 'priceListFab',
+       floatingActionButton: FloatingActionButton(
+         heroTag: 'priceListFab',
+          // セール情報を追加する画面へ遷移
           onPressed: () {
             Navigator.push(
               context,
@@ -152,11 +153,13 @@ class _PriceCategoryListState extends State<PriceCategoryList> {
           child: Row(
             children: [
               Expanded(
+                // セール情報の検索テキストフィールド
                 child: TextField(
                   controller: _viewModel.controller,
                   decoration: InputDecoration(
                     labelText: AppLocalizations.of(context)!.searchHint,
                   ),
+                  // 入力値が変わったら検索条件を更新
                   onChanged: _viewModel.setSearch,
                 ),
               ),


### PR DESCRIPTION
## Summary
- カテゴリ設定画面の色コード文字列を修正
- 各画面でイベント内容のコメントを追加

## Testing
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68726b8120b8832eb2611700353d39f7