### PR TITLE
fix item type selection in edit page

### DIFF
--- a/lib/edit_inventory_page.dart
+++ b/lib/edit_inventory_page.dart
@@ -138,15 +138,18 @@ class _EditInventoryPageState extends State<EditInventoryPage> {
               ),
               const SizedBox(height: 12),
               Builder(builder: (context) {
-                // 選択中カテゴリに該当する品種リストを取得
-                final itemTypes =
-                    _viewModel.typesMap[_viewModel.category?.name] ?? ['その他'];
-                // 品種リストに現在の値が無ければ自動的に先頭に切り替える
-                final selectedType = itemTypes.contains(_viewModel.itemType)
+                // 選択中カテゴリに対応する品種リストを取得。未読み込み時は現在値のみ表示
+                final loadedTypes = _viewModel.typesMap[_viewModel.category?.name];
+                // 未読み込みの場合は現在の品種だけをリスト化
+                final itemTypes = loadedTypes ?? [_viewModel.itemType];
+                // 品種リストに現在の値が存在しない場合のみ更新
+                final selectedType = loadedTypes == null
                     ? _viewModel.itemType
-                    : itemTypes.first;
-                if (selectedType != _viewModel.itemType) {
-                  // ビルド完了後に状態を更新する
+                    : itemTypes.contains(_viewModel.itemType)
+                        ? _viewModel.itemType
+                        : itemTypes.first;
+                if (_viewModel.typesLoaded && selectedType != _viewModel.itemType) {
+                  // ビルド完了後に ViewModel の値を更新
                   WidgetsBinding.instance.addPostFrameCallback((_) {
                     _viewModel.changeItemType(selectedType);
                   });
@@ -154,8 +157,9 @@ class _EditInventoryPageState extends State<EditInventoryPage> {
                 return DropdownButtonFormField<String>(
                   decoration: InputDecoration(
                       labelText: AppLocalizations.of(context)!.itemType),
-                  value:
-                      itemTypes.contains(_viewModel.itemType) ? _viewModel.itemType : null,
+                  value: itemTypes.contains(_viewModel.itemType)
+                      ? _viewModel.itemType
+                      : null,
                   items: itemTypes
                       .map((t) => DropdownMenuItem(
                             value: t,

--- a/lib/presentation/viewmodels/edit_inventory_viewmodel.dart
+++ b/lib/presentation/viewmodels/edit_inventory_viewmodel.dart
@@ -50,6 +50,9 @@ class EditInventoryViewModel extends ChangeNotifier {
   Map<String, List<String>> typesMap = {};
   StreamSubscription? _typeSub;
 
+  /// Firestore から品種リストを受信済みかどうか
+  bool typesLoaded = false;
+
   /// 単位の選択肢
   // ミリリットル、グラム、キログラムも含めた選択肢
   // 選択可能な単位一覧を定数から生成
@@ -122,11 +125,21 @@ class EditInventoryViewModel extends ChangeNotifier {
         final list = typesMap.putIfAbsent(cat, () => []);
         if (!list.contains(name)) list.add(name);
       }
+      // Firestore から一覧を取得できたのでフラグを立てる
+      typesLoaded = true;
       final types = typesMap[category?.name];
       if (types != null && types.isNotEmpty) {
-        if (!types.contains(itemType)) itemType = types.first;
+        // 既に設定されている品種がリストにあるかを確認
+        if (itemType.isEmpty) {
+          itemType = types.first;
+        } else if (!types.contains(itemType)) {
+          // リストに存在しない場合のみ先頭の品種へ変更
+          itemType = types.first;
+        }
       } else {
-        itemType = itemTypeOther;
+        if (itemType.isEmpty) {
+          itemType = itemTypeOther;
+        }
       }
       notifyListeners();
     });

--- a/test/edit_inventory_page_test.dart
+++ b/test/edit_inventory_page_test.dart
@@ -41,7 +41,7 @@ void main() {
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
   });
 
-  testWidgets('品種リストに無い初期値は自動で先頭に変更される',
+  testWidgets('品種リストに無い初期値でもそのまま表示される',
       (WidgetTester tester) async {
     final cat = Category(id: 1, name: '日用品', createdAt: DateTime.now());
     await tester.pumpWidget(
@@ -63,7 +63,7 @@ void main() {
     await tester.pump();
     final dropdown = tester.widget<DropdownButtonFormField<String>>(
         find.byType(DropdownButtonFormField<String>).first);
-    expect(dropdown.initialValue ?? dropdown.value, 'その他');
+    expect(dropdown.initialValue ?? dropdown.value, '存在しない品種');
   });
 
   testWidgets('容量入力欄が表示される', (WidgetTester tester) async {


### PR DESCRIPTION
## Summary
- 編集画面でFirestoreの品種読込前に値が書き換わる問題を修正
- ViewModelにtypesLoadedを追加
- 初期値にない品種は読み込み完了後のみ先頭に変更
- テストを修正

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687305e7e510832ea0134614a9586e8f