### PR TITLE
Fix import for PriceHistoryPage

### DIFF
--- a/lib/price_history_page.dart
+++ b/lib/price_history_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:oouchi_stock/i18n/app_localizations.dart';
 import 'domain/entities/price_info.dart';
 import 'presentation/viewmodels/price_history_viewmodel.dart';
+import 'domain/usecases/watch_price_by_type.dart';
+import 'domain/usecases/delete_price_info.dart';
 // 数量や容量の単位をユーザーの言語設定に合わせて表示する
 import 'util/unit_localization.dart';
 


### PR DESCRIPTION
## Summary
- fix undefined class error by importing `WatchPriceByType` and `DeletePriceInfo`
- 価格履歴画面の必要ユースケースを読み込むように修正

## Testing
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873b75023c4832ea2120d271c42467c