### PR TITLE
Fix import for DeletePriceInfo

### DIFF
--- a/lib/price_history_page.dart
+++ b/lib/price_history_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:oouchi_stock/i18n/app_localizations.dart';
 import 'domain/entities/price_info.dart';
 import 'presentation/viewmodels/price_history_viewmodel.dart';
+import 'domain/usecases/delete_price_info.dart';
+import 'domain/usecases/watch_price_by_type.dart';
 // 数量や容量の単位をユーザーの言語設定に合わせて表示する
 import 'util/unit_localization.dart';
 
@@ -93,6 +95,7 @@ class _PriceHistoryPageState extends State<PriceHistoryPage> {
                     );
                     return res ?? false;
                   },
+                  // スワイプ確定後に履歴を削除する
                   onDismissed: (_) async => _viewModel.delete(p.id),
                   background: Container(
                     color: Colors.red,


### PR DESCRIPTION
## Summary
- 修正: PriceHistoryPageでDeletePriceInfoなどのインポート漏れを解消
- スワイプ削除時の処理にコメントを追加

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6873b76244ec832ea486067e1df957e4