### PR TITLE
InventoryDetail と PriceDetail の context 明示化

### DIFF
--- a/lib/inventory_detail_page.dart
+++ b/lib/inventory_detail_page.dart
@@ -117,7 +117,8 @@ class InventoryDetailPage extends StatelessWidget {
                     height: MediaQuery.of(context).size.height / 3,
                     child: ListView(
                       children: list
-                          .map((e) => _buildHistoryTile(e, localizeUnit(context, inv.unit)))
+                          .map((e) =>
+                              _buildHistoryTile(context, e, localizeUnit(context, inv.unit)))
                           .toList(),
                     ),
                   ),
@@ -148,7 +149,12 @@ class InventoryDetailPage extends StatelessWidget {
     return DateFormat('yyyy/MM/dd HH:mm').format(date);
   }
 
-  Widget _buildHistoryTile(HistoryEntry e, String unit) {
+  /// 履歴エントリ1件を表示するウィジェット
+  /// [context] 表示に利用する BuildContext
+  /// [e] 履歴データ
+  /// [unit] 容量の単位
+  Widget _buildHistoryTile(
+      BuildContext context, HistoryEntry e, String unit) {
     final diffSign = e.diff >= 0 ? '+' : '-';
     // 数量履歴は単位を付けずに表示
     final quantityText = '${e.before.toStringAsFixed(1)} -> ${e.after.toStringAsFixed(1)} ($diffSign${e.diff.abs().toStringAsFixed(1)})';

--- a/lib/price_detail_page.dart
+++ b/lib/price_detail_page.dart
@@ -37,26 +37,27 @@ class PriceDetailPage extends StatelessWidget {
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
-          _buildRow(loc.category, info.category),
-          _buildRow(loc.itemType, info.itemType),
-          _buildRow(loc.itemName, info.itemName),
-          _buildRow(loc.checkedDate(_formatDate(info.checkedAt)), ''),
-          _buildRow(loc.expiry(_formatDate(info.expiry)), ''),
+          _buildRow(context, loc.category, info.category),
+          _buildRow(context, loc.itemType, info.itemType),
+          _buildRow(context, loc.itemName, info.itemName),
+          _buildRow(context, loc.checkedDate(_formatDate(info.checkedAt)), ''),
+          _buildRow(context, loc.expiry(_formatDate(info.expiry)), ''),
           // 数量は単位を付けずに表示
           _buildRow(
+            context,
             loc.count,
             info.count.toString(),
           ),
           // 総容量は単位付きで表示
-          _buildRow(loc.totalVolumeLabel,
+          _buildRow(context, loc.totalVolumeLabel,
               '${info.totalVolume.toString()}${localizeUnit(context, info.unit)}'),
-          _buildRow(loc.regularPrice, info.regularPrice.toString()),
-          _buildRow(loc.salePrice, info.salePrice.toString()),
-          _buildRow(loc.unitPriceLabel, info.unitPrice.toStringAsFixed(2)),
-          _buildRow(loc.shop, info.shop),
+          _buildRow(context, loc.regularPrice, info.regularPrice.toString()),
+          _buildRow(context, loc.salePrice, info.salePrice.toString()),
+          _buildRow(context, loc.unitPriceLabel, info.unitPrice.toStringAsFixed(2)),
+          _buildRow(context, loc.shop, info.shop),
           if (info.approvalUrl.isNotEmpty)
-            _buildRow(loc.approvalUrl, info.approvalUrl, textStyle),
-          if (info.memo.isNotEmpty) _buildRow(loc.memo, info.memo, textStyle),
+            _buildRow(context, loc.approvalUrl, info.approvalUrl, textStyle),
+          if (info.memo.isNotEmpty) _buildRow(context, loc.memo, info.memo, textStyle),
         ],
       ),
     );
@@ -64,7 +65,14 @@ class PriceDetailPage extends StatelessWidget {
 
   String _formatDate(DateTime d) => '${d.year}/${d.month}/${d.day}';
 
-  Widget _buildRow(String label, String value, [TextStyle? style]) {
+  /// ラベルと値を横並びで表示する共通行ウィジェット
+  /// [context] テーマ取得に利用する BuildContext
+  /// [label] 左側に表示するラベル
+  /// [value] 右側に表示する値
+  /// [style] 任意で指定するテキストスタイル
+  Widget _buildRow(
+      BuildContext context, String label, String value,
+      [TextStyle? style]) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),
       child: Row(

--- a/test/inventory_detail_page_test.dart
+++ b/test/inventory_detail_page_test.dart
@@ -140,6 +140,9 @@ void main() {
 
   testWidgets('履歴タイルのスタイルを確認', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('ja'),
       home: InventoryDetailPage(
         inventoryId: '1',
         categories: [Category(id: 1, name: '日用品', createdAt: DateTime.now())],

--- a/test/price_detail_page_test.dart
+++ b/test/price_detail_page_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:oouchi_stock/price_detail_page.dart';
 import 'package:oouchi_stock/domain/entities/price_info.dart';
 import 'package:oouchi_stock/edit_price_page.dart';
+import 'package:oouchi_stock/i18n/app_localizations.dart';
 
 void main() {
   testWidgets('PriceDetailPage が詳細を表示する', (WidgetTester tester) async {
@@ -25,7 +26,12 @@ void main() {
       unitPrice: 150,
       expiry: DateTime(2023, 1, 2),
     );
-    await tester.pumpWidget(MaterialApp(home: PriceDetailPage(info: info)));
+    await tester.pumpWidget(MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      locale: const Locale('ja'),
+      home: PriceDetailPage(info: info),
+    ));
     expect(find.text('テスト商品'), findsOneWidget);
     expect(find.text('日用品'), findsOneWidget);
     expect(find.textContaining('150'), findsWidgets);


### PR DESCRIPTION
## Summary
- InventoryDetailPage の履歴表示メソッドに BuildContext を渡すよう変更
- PriceDetailPage の情報行作成メソッドに BuildContext を渡すよう修正
- 対応に伴いテストで MaterialApp のローカライズ設定を追加

## Testing
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874f78fbaa4832eba5fd9bda2e8c4bf