### PR TITLE
総容量表示の単位位置を修正

### DIFF
--- a/lib/add_inventory_page.dart
+++ b/lib/add_inventory_page.dart
@@ -173,7 +173,7 @@ class _AddInventoryPageState extends State<AddInventoryPage> {
                 onChanged: (value) => _viewModel.setUnit(value!),
               ),
               const SizedBox(height: 12),
-              // 総容量表示（単位→値の順）
+              // 総容量表示（値→単位の順）
               Text(
                 AppLocalizations.of(context)!.totalVolume(
                   localizeUnit(context, _viewModel.unit),

--- a/lib/add_price_page.dart
+++ b/lib/add_price_page.dart
@@ -135,7 +135,7 @@ class _AddPricePageState extends State<AddPricePage> {
                       onChanged: (v) => _viewModel.memo = v,
                     ),
                     const SizedBox(height: 12),
-                    // 合計容量を大きめの文字で表示（単位→値の順）
+                    // 合計容量を大きめの文字で表示（値→単位の順）
                     Text(
                       AppLocalizations.of(context)!.totalVolume(
                         localizeUnit(

--- a/lib/edit_price_page.dart
+++ b/lib/edit_price_page.dart
@@ -142,7 +142,7 @@ class _EditPricePageState extends State<EditPricePage> {
                           onChanged: (v) => _viewModel.memo = v,
                         ),
                         const SizedBox(height: 12),
-                        // 合計容量を単位→値の順で表示
+                        // 合計容量を値→単位の順で表示
                         Text(
                           loc.totalVolume(
                             localizeUnit(

--- a/lib/i18n/app_en.arb
+++ b/lib/i18n/app_en.arb
@@ -77,7 +77,7 @@
   "expiry": "Expiration: {date}",
   "expiryLabel": "Expiration",
   "showExpired": "Show expired",
-  "totalVolume": "Total volume: {unit}{value}",
+  "totalVolume": "Total volume: {value}{unit}",
   "unitPrice": "Unit price: {value}",
   "checkedDate": "Checked: {date}",
   "categorySettings": "Category Settings",

--- a/lib/i18n/app_ja.arb
+++ b/lib/i18n/app_ja.arb
@@ -77,7 +77,7 @@
   "expiry": "期限: {date}",
   "expiryLabel": "期限",
   "showExpired": "期限切れも表示",
-  "totalVolume": "総容量: {unit}{value}",
+  "totalVolume": "総容量: {value}{unit}",
   "unitPrice": "単価: {value}",
   "checkedDate": "確認日: {date}",
   "categorySettings": "カテゴリ設定",

--- a/test/add_inventory_page_test.dart
+++ b/test/add_inventory_page_test.dart
@@ -69,8 +69,8 @@ void main() {
     await tester.enterText(find.byType(TextFormField).at(1), '2');
     await tester.pump();
 
-    // 単位を先に表示した総容量を確認
-    expect(find.text('総容量: 個2.0'), findsOneWidget);
+    // 値の後ろに単位を表示した総容量を確認
+    expect(find.text('総容量: 2.0個'), findsOneWidget);
   });
 
   testWidgets('品種リストに無い初期値は自動で先頭に変更される',


### PR DESCRIPTION
## 概要
カードや入力画面で表示される総容量の表記が「単位→値」となっていたため、「値→単位」に修正しました。併せてコメントとテストも更新しています。

## 主な変更点
- `totalVolume` のローカライズ文字列を値の後に単位が来る形へ変更
- 商品追加・価格追加・価格編集画面の表示コメントを更新
- テスト `add_inventory_page_test.dart` を新表記に合わせて修正

## テスト
- `flutter test` を実行しようとしましたが、環境に Flutter が存在せず実行できませんでした。

------
https://chatgpt.com/codex/tasks/task_e_68750df4b7d8832ebc4eb87a3a3b5c85