### PR TITLE
Fix removedIds field scope

### DIFF
--- a/lib/inventory_page.dart
+++ b/lib/inventory_page.dart
@@ -25,8 +25,6 @@ class InventoryPage extends StatefulWidget {
 class InventoryPageState extends State<InventoryPage> {
   /// 画面全体の状態を管理する ViewModel
   late final InventoryPageViewModel _viewModel;
-  /// スワイプで削除した在庫IDを一時的に保持
-  final Set<String> _removedIds = {};
 
   /// 画面が再表示された際にカテゴリを最新化する
   Future<void> refresh() async {
@@ -153,6 +151,8 @@ class InventoryList extends StatefulWidget {
 class _InventoryListState extends State<InventoryList> {
   /// リスト表示を制御する ViewModel
   late final InventoryListViewModel _viewModel;
+  /// Dismissible のアニメーション中に一時保持する削除済み在庫ID
+  final Set<String> _removedIds = {};
 
   @override
   void dispose() {

--- a/lib/price_list_page.dart
+++ b/lib/price_list_page.dart
@@ -21,8 +21,6 @@ class PriceListPage extends StatefulWidget {
 class _PriceListPageState extends State<PriceListPage> {
   /// 画面全体の状態を管理する ViewModel
   late final PriceListViewModel _viewModel;
-  /// スワイプ削除されたID一覧
-  final Set<String> _removedIds = {};
 
   @override
   void initState() {
@@ -131,6 +129,8 @@ class PriceCategoryList extends StatefulWidget {
 class _PriceCategoryListState extends State<PriceCategoryList> {
   /// カテゴリリストを管理する ViewModel
   late final PriceCategoryListViewModel _viewModel;
+  /// Dismissible処理中に保持する削除済みID一覧
+  final Set<String> _removedIds = {};
 
   @override
   void initState() {


### PR DESCRIPTION
## Summary
- 在庫一覧ページとセール情報ページの削除ID保持用フィールドを各リストのStateへ移動

## Testing
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687513a74770832e81f4c8604011ee92