### PR TITLE
総容量表示の順序を修正

### DIFF
--- a/lib/add_inventory_page.dart
+++ b/lib/add_inventory_page.dart
@@ -173,14 +173,14 @@ class _AddInventoryPageState extends State<AddInventoryPage> {
                 onChanged: (value) => _viewModel.setUnit(value!),
               ),
               const SizedBox(height: 12),
-              // 総容量表示（値→単位の順）
-              Text(
-                AppLocalizations.of(context)!.totalVolume(
-                  localizeUnit(context, _viewModel.unit),
-                  _viewModel.totalVolume.toStringAsFixed(2),
+                // 総容量表示（値→単位の順）
+                Text(
+                  AppLocalizations.of(context)!.totalVolume(
+                    _viewModel.totalVolume.toStringAsFixed(2),
+                    localizeUnit(context, _viewModel.unit),
+                  ),
+                  style: const TextStyle(fontSize: 20),
                 ),
-                style: const TextStyle(fontSize: 20),
-              ),
               const SizedBox(height: 12),
               // メモの入力（任意）
               TextFormField(

--- a/lib/add_price_page.dart
+++ b/lib/add_price_page.dart
@@ -135,15 +135,15 @@ class _AddPricePageState extends State<AddPricePage> {
                       onChanged: (v) => _viewModel.memo = v,
                     ),
                     const SizedBox(height: 12),
-                    // 合計容量を大きめの文字で表示（値→単位の順）
-                    Text(
-                      AppLocalizations.of(context)!.totalVolume(
-                        localizeUnit(
-                            context, _viewModel.inventory?.unit ?? ''),
-                        _viewModel.totalVolume.toStringAsFixed(2),
+                      // 合計容量を大きめの文字で表示（値→単位の順）
+                      Text(
+                        AppLocalizations.of(context)!.totalVolume(
+                          _viewModel.totalVolume.toStringAsFixed(2),
+                          localizeUnit(
+                              context, _viewModel.inventory?.unit ?? ''),
+                        ),
+                        style: const TextStyle(fontSize: 20),
                       ),
-                      style: const TextStyle(fontSize: 20),
-                    ),
                     // 単価を大きめの文字で表示
                     Text(
                       AppLocalizations.of(context)!

--- a/lib/edit_price_page.dart
+++ b/lib/edit_price_page.dart
@@ -142,15 +142,15 @@ class _EditPricePageState extends State<EditPricePage> {
                           onChanged: (v) => _viewModel.memo = v,
                         ),
                         const SizedBox(height: 12),
-                        // 合計容量を値→単位の順で表示
-                        Text(
-                          loc.totalVolume(
-                            localizeUnit(
-                                context, _viewModel.inventory?.unit ?? ''),
-                            _viewModel.totalVolume.toStringAsFixed(2),
+                          // 合計容量を値→単位の順で表示
+                          Text(
+                            loc.totalVolume(
+                              _viewModel.totalVolume.toStringAsFixed(2),
+                              localizeUnit(
+                                  context, _viewModel.inventory?.unit ?? ''),
+                            ),
+                            style: const TextStyle(fontSize: 20),
                           ),
-                          style: const TextStyle(fontSize: 20),
-                        ),
                         Text(
                           loc.unitPrice(_viewModel.unitPrice.toStringAsFixed(2)),
                           style: const TextStyle(fontSize: 20),


### PR DESCRIPTION
## Summary
- 総容量表示の値と単位の順序を修正
- `AddInventoryPage` `AddPricePage` `EditPricePage` で値→単位の順に変更

## Testing
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877b6ba7ab8832eb608f684c512c337