### PR TITLE
remainingFormat の引数順を修正

### DIFF
--- a/lib/add_inventory_page.dart
+++ b/lib/add_inventory_page.dart
@@ -173,14 +173,14 @@ class _AddInventoryPageState extends State<AddInventoryPage> {
                 onChanged: (value) => _viewModel.setUnit(value!),
               ),
               const SizedBox(height: 12),
-              // 総容量表示（値→単位の順）
-              Text(
-                AppLocalizations.of(context)!.totalVolume(
-                  localizeUnit(context, _viewModel.unit),
-                  _viewModel.totalVolume.toStringAsFixed(2),
+                // 商品追加画面で総容量を表示（値の後ろに単位を付与）
+                Text(
+                  AppLocalizations.of(context)!.totalVolume(
+                    localizeUnit(context, _viewModel.unit),
+                    _viewModel.totalVolume.toStringAsFixed(2),
+                  ),
+                  style: const TextStyle(fontSize: 20),
                 ),
-                style: const TextStyle(fontSize: 20),
-              ),
               const SizedBox(height: 12),
               // メモの入力（任意）
               TextFormField(

--- a/lib/add_price_page.dart
+++ b/lib/add_price_page.dart
@@ -135,15 +135,15 @@ class _AddPricePageState extends State<AddPricePage> {
                       onChanged: (v) => _viewModel.memo = v,
                     ),
                     const SizedBox(height: 12),
-                    // 合計容量を大きめの文字で表示（値→単位の順）
-                    Text(
-                      AppLocalizations.of(context)!.totalVolume(
-                        localizeUnit(
-                            context, _viewModel.inventory?.unit ?? ''),
-                        _viewModel.totalVolume.toStringAsFixed(2),
+                      // セール情報追加画面: 合計容量を値の後ろに単位を付けて表示
+                      Text(
+                        AppLocalizations.of(context)!.totalVolume(
+                          localizeUnit(
+                              context, _viewModel.inventory?.unit ?? ''),
+                          _viewModel.totalVolume.toStringAsFixed(2),
+                        ),
+                        style: const TextStyle(fontSize: 20),
                       ),
-                      style: const TextStyle(fontSize: 20),
-                    ),
                     // 単価を大きめの文字で表示
                     Text(
                       AppLocalizations.of(context)!

--- a/lib/edit_price_page.dart
+++ b/lib/edit_price_page.dart
@@ -142,15 +142,15 @@ class _EditPricePageState extends State<EditPricePage> {
                           onChanged: (v) => _viewModel.memo = v,
                         ),
                         const SizedBox(height: 12),
-                        // 合計容量を値→単位の順で表示
-                        Text(
-                          loc.totalVolume(
-                            localizeUnit(
-                                context, _viewModel.inventory?.unit ?? ''),
-                            _viewModel.totalVolume.toStringAsFixed(2),
+                          // セール情報編集画面: 合計容量を値の後ろに単位を付けて表示
+                          Text(
+                            loc.totalVolume(
+                              localizeUnit(
+                                  context, _viewModel.inventory?.unit ?? ''),
+                              _viewModel.totalVolume.toStringAsFixed(2),
+                            ),
+                            style: const TextStyle(fontSize: 20),
                           ),
-                          style: const TextStyle(fontSize: 20),
-                        ),
                         Text(
                           loc.unitPrice(_viewModel.unitPrice.toStringAsFixed(2)),
                           style: const TextStyle(fontSize: 20),

--- a/lib/util/inventory_display.dart
+++ b/lib/util/inventory_display.dart
@@ -14,6 +14,6 @@ String formatRemaining(BuildContext context, Inventory inv) {
           ? inv.totalVolume
           : inv.calculateTotalVolume())
       .toStringAsFixed(1);
-  // remainingFormat の引数は (数量, 総容量, 単位) の順で指定する
-  return loc.remainingFormat(count, total, unit);
+  // remainingFormat の引数は (数量, 単位, 総容量) の順で指定する
+  return loc.remainingFormat(count, unit, total);
 }

--- a/test/inventory_display_test.dart
+++ b/test/inventory_display_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oouchi_stock/domain/entities/inventory.dart';
+import 'package:oouchi_stock/i18n/app_localizations.dart';
+import 'package:oouchi_stock/util/inventory_display.dart';
+
+void main() {
+  testWidgets('formatRemainingは数量→単位→総容量の順で表示', (tester) async {
+    final inv = Inventory(
+      id: '1',
+      itemName: '水',
+      category: '飲料',
+      itemType: 'その他',
+      quantity: 2,
+      volume: 100,
+      totalVolume: 200,
+      unit: 'ミリリットル',
+      createdAt: DateTime(2020),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('ja'),
+        home: Builder(
+          builder: (context) {
+            return Text(formatRemaining(context, inv));
+          },
+        ),
+      ),
+    );
+
+    await tester.pump();
+    expect(find.text('残り2.0(200.0ミリリットル)'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- `formatRemaining` の内部で `remainingFormat` を正しい順序(数量→単位→総容量)で呼び出すよう修正
- `formatRemaining` の表示内容を確認するテストを追加

## Testing
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877b6ba7ab8832eb608f684c512c337