### PR TITLE
カード表示スタイルの統一

### DIFF
--- a/docs/user_manual_ja.md
+++ b/docs/user_manual_ja.md
@@ -13,6 +13,7 @@
 - 詳細表示: **18px**
 
 これらのサイズは `lib/theme.dart` の `AppTheme` クラスで定義されており、画面間で一貫した表示を実現します。
+BuyListCard、SaleItemCard、PredictionCard も InventoryCard と同じスタイルを採用し、カード間で統一された読みやすさを確保しています。
 なお、広告表示機能は Android と iOS のみ対応しています。`google_mobile_ads` パッケージのバージョン 4.0.0 以上が必要です。
 動作させるには AndroidManifest と iOS の Info.plist にそれぞれ有効な AdMob の App ID を設定する必要があります。テスト用途であればサンプル ID を利用できます。
 WebView が無効、またはインストールされていない端末では広告初期化時にエラーログが表示されます。広告機能を利用するには Android System WebView もしくは Chrome を有効にしてください。

--- a/lib/widgets/buy_list_card.dart
+++ b/lib/widgets/buy_list_card.dart
@@ -9,6 +9,9 @@ import '../util/inventory_display.dart';
 import '../util/buy_item_reason_label.dart';
 
 /// BuyListPage で使用される、買い物リストを表示するカードウィジェット
+///
+/// 画面名: BuyListPage
+/// スワイプで削除、タップで在庫詳細画面へ遷移するイベントを管理
 class BuyListCard extends StatefulWidget {
   /// 表示する買い物データ
   final BuyItem item;
@@ -178,15 +181,26 @@ class _BuyListCardState extends State<BuyListCard> {
         child: widget.item.inventoryId == null
             // 手入力アイテムは理由も表示
             ? ListTile(
-                title: Text(widget.item.name),
-                subtitle: Text(widget.item.reason.label(loc)),
+                title: Text(
+                  widget.item.name,
+                  // 在庫リストカードと統一したタイトルフォント
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                subtitle: Text(
+                  widget.item.reason.label(loc),
+                  // 理由表示は補足用のスタイル
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
               )
             : StreamBuilder<Inventory?>(
                 stream: widget.watchInventory(widget.item.inventoryId!),
                 builder: (context, snapshot) {
                   if (!snapshot.hasData) {
                     return ListTile(
-                      title: Text(widget.item.name),
+                      title: Text(
+                        widget.item.name,
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
                       // 詳細画面へ遷移するタップイベント
                       onTap: () => _openDetail(context),
                     );
@@ -203,17 +217,28 @@ class _BuyListCardState extends State<BuyListCard> {
                       final subtitle =
                           '${formatRemaining(context, inv)}$daysText';
                       return ListTile(
-                        // 商品名の後ろに品種を表示
-                        title: Text('${inv.itemName} / ${inv.itemType}'),
+                        // 商品名と品種をまとめて表示
+                        title: Text(
+                          '${inv.itemName} / ${inv.itemType}',
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
                         subtitle: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Text(subtitle),
-                            Text(widget.item.reason.label(loc),
-                                style:
-                                    Theme.of(context).textTheme.bodySmall),
+                            Text(
+                              subtitle,
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .bodyMedium
+                                  ?.copyWith(color: Colors.black87),
+                            ),
+                            Text(
+                              widget.item.reason.label(loc),
+                              style: Theme.of(context).textTheme.bodySmall,
+                            ),
                           ],
                         ),
+                        // カードタップで在庫詳細画面へ遷移
                         onTap: () => _openDetail(context),
                       );
                     },

--- a/lib/widgets/prediction_card.dart
+++ b/lib/widgets/prediction_card.dart
@@ -9,6 +9,9 @@ import '../util/buy_item_reason_label.dart';
 
 /// 買い物予報画面で使用するカードウィジェット
 /// 右スワイプで予報リストから削除できる
+///
+/// 画面名: PredictionPage
+/// スワイプで削除、ボタンで買い物リストへ追加する処理を持つ
 class PredictionCard extends StatefulWidget {
   /// 表示するアイテム
   final BuyItem item;
@@ -81,7 +84,10 @@ class _PredictionCardState extends State<PredictionCard> {
             return Card(
               margin: const EdgeInsets.only(bottom: 12),
               child: ListTile(
-                title: Text(widget.item.name),
+                title: Text(
+                  widget.item.name,
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
                 // 詳細画面へ遷移するタップイベント
                 onTap: () => _openDetail(context),
               ),
@@ -102,16 +108,28 @@ class _PredictionCardState extends State<PredictionCard> {
                 // 買い物予報画面の1アイテムをカード表示
                 margin: const EdgeInsets.only(bottom: 12),
                 child: ListTile(
-                  // 商品名の後に品種を表示する
-                        title: Text('${inv.itemName} / ${inv.itemType}'),
+                  // 商品名と品種の表示
+                  title: Text(
+                    '${inv.itemName} / ${inv.itemType}',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
                   subtitle: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(subtitle),
-                      Text(widget.item.reason.label(loc),
-                          style: Theme.of(context).textTheme.bodySmall),
+                      Text(
+                        subtitle,
+                        style: Theme.of(context)
+                            .textTheme
+                            .bodyMedium
+                            ?.copyWith(color: Colors.black87),
+                      ),
+                      Text(
+                        widget.item.reason.label(loc),
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
                     ],
                   ),
+                  // タップで在庫詳細を開く
                   onTap: () => _openDetail(context),
                   // 買い物リストへ追加するボタン
                   trailing: IconButton(

--- a/lib/widgets/sale_item_card.dart
+++ b/lib/widgets/sale_item_card.dart
@@ -5,6 +5,9 @@ import '../models/sale_item.dart';
 import '../util/localization_extensions.dart';
 
 /// セール情報画面で使用するカードウィジェット
+///
+/// 画面名: SaleListPage
+/// セール商品を買い物リストへ追加するボタンの処理を持つ
 class SaleItemCard extends StatelessWidget {
   /// 表示するセール情報
   final SaleItem item;
@@ -48,14 +51,30 @@ class SaleItemCard extends StatelessWidget {
               ],
             ),
             const SizedBox(height: 4),
-            Text(item.shop),
+            Text(
+              item.shop,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyMedium
+                  ?.copyWith(color: Colors.black87),
+            ),
             const SizedBox(height: 4),
             Text(
               '${loc.salePriceLabel(item.salePrice.toStringAsFixed(0))}  '
               '${loc.regularPriceLabel(item.regularPrice.toStringAsFixed(0))}',
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyMedium
+                  ?.copyWith(color: Colors.black87),
             ),
             const SizedBox(height: 4),
-            Text(loc.salePeriod(period)),
+            Text(
+              loc.salePeriod(period),
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyMedium
+                  ?.copyWith(color: Colors.black87),
+            ),
             const SizedBox(height: 4),
             Text(
               loc.daysLeft(daysLeft.toString()),
@@ -63,10 +82,17 @@ class SaleItemCard extends StatelessWidget {
               style: Theme.of(context)
                   .textTheme
                   .bodyMedium
-                  ?.copyWith(color: expired ? Colors.red : null),
+                  ?.copyWith(
+                      color: expired ? Colors.red : Colors.black87),
             ),
             const SizedBox(height: 4),
-            Text(loc.stockInfo(item.stock)),
+            Text(
+              loc.stockInfo(item.stock),
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyMedium
+                  ?.copyWith(color: Colors.black87),
+            ),
             const SizedBox(height: 8),
             Align(
               alignment: Alignment.centerRight,


### PR DESCRIPTION
## Summary
- BuyListCard, SaleItemCard, PredictionCard のフォントやボールドを InventoryCard と同じスタイルに統一
- 各ウィジェットに画面名とイベント内容を日本語でコメント追加
- 取扱説明書にカードフォント統一の説明を追記

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ad2f71b88832e811871d5616a8afd