### PR TITLE
ビルドエラー修正

### DIFF
--- a/lib/add_category_page.dart
+++ b/lib/add_category_page.dart
@@ -59,6 +59,7 @@ class _AddCategoryPageState extends State<AddCategoryPage> {
                 onSelected: (c) => setState(() => _viewModel.color = c),
               ),
               const SizedBox(height: 24),
+              // 保存ボタンをタップしたときの処理
               ElevatedButton(
                 onPressed: () async {
                   if (_viewModel.formKey.currentState!.validate()) {

--- a/lib/widgets/color_picker.dart
+++ b/lib/widgets/color_picker.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 /// 画面名: カテゴリ登録・編集ページ
 class ColorPicker extends StatelessWidget {
   final List<Color> colors;
-  final Color selected;
+  final Color? selected;
   final ValueChanged<Color> onSelected;
   const ColorPicker({
     super.key,
@@ -30,7 +30,9 @@ class ColorPicker extends StatelessWidget {
                   color: c,
                   shape: BoxShape.circle,
                   border: Border.all(
-                    color: selected == c ? Colors.black : Colors.transparent,
+                    color: selected != null && selected == c
+                        ? Colors.black
+                        : Colors.transparent,
                     width: 3,
                   ),
                 ),

--- a/lib/widgets/prediction_card.dart
+++ b/lib/widgets/prediction_card.dart
@@ -85,7 +85,7 @@ class _PredictionCardState extends State<PredictionCard> {
           }
           final inv = snapshot.data!;
           return FutureBuilder<int>(
-                    future: widget.calcDaysLeft(inv),
+            future: widget.calcDaysLeft(inv),
             builder: (context, daysSnapshot) {
               final daysText = daysSnapshot.hasData
                   ? ' ・ ${loc.daysLeft(daysSnapshot.data!.toString())}'
@@ -94,46 +94,50 @@ class _PredictionCardState extends State<PredictionCard> {
               // 予報画面カードで在庫数量と総容量をまとめて表示
               final subtitle =
                   '${formatRemaining(context, inv)}$daysText';
-                      return ListTile(
+
+              return ListTile(
                 // 商品名と品種の表示
                 title: Text(
                   '${inv.itemName} / ${inv.itemType}',
-                    style: Theme.of(context).textTheme.titleMedium,
-                  ),
-                  subtitle: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        subtitle,
-                        style: Theme.of(context)
-                            .textTheme
-                            .bodyMedium
-                            ?.copyWith(color: Colors.black87),
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                subtitle: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      subtitle,
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodyMedium
+                          ?.copyWith(color: Colors.black87),
+                    ),
+                    Text(
+                      widget.item.reason.label(loc),
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  ],
+                ),
+                // タップで在庫詳細を開く
+                onTap: () => _openDetail(context),
+                // 買い物リストへ追加するボタン
+                trailing: IconButton(
+                  icon: const Icon(Icons.playlist_add),
+                  onPressed: () async {
+                    await widget.addToBuyList(
+                      BuyItem(
+                        inv.itemName,
+                        inv.category,
+                        inv.id,
+                        BuyItemReason.prediction,
                       ),
-                      Text(
-                        widget.item.reason.label(loc),
-                        style: Theme.of(context).textTheme.bodySmall,
-                      ),
-                    ],
-                  ),
-                  // タップで在庫詳細を開く
-                  onTap: () => _openDetail(context),
-                  // 買い物リストへ追加するボタン
-                  trailing: IconButton(
-                    icon: const Icon(Icons.playlist_add),
-                    onPressed: () async {
-                      await widget.addToBuyList(
-                        BuyItem(inv.itemName, inv.category, inv.id,
-                            BuyItemReason.prediction),
+                    );
+                    await widget.removePrediction(widget.item);
+                    if (context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(content: Text(loc.addedBuyItem)),
                       );
-                      await widget.removePrediction(widget.item);
-                      if (context.mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(content: Text(loc.addedBuyItem)),
-                        );
-                      }
-                    },
-                  ),
+                    }
+                  },
                 ),
               );
             },


### PR DESCRIPTION
## 概要
- カラーピッカーが null を扱えるよう型を修正
- AddCategoryPage に保存ボタンの操作説明を追加
- PredictionCard のレイアウトを整理しビルドエラーを解消

## テスト
- `flutter test` は環境に Flutter が無いため実行できず

------
https://chatgpt.com/codex/tasks/task_e_687ad8821920832e93b2f2fe780732ee