### PR TITLE
カテゴリ編集画面から色設定削除

### DIFF
--- a/lib/edit_category_page.dart
+++ b/lib/edit_category_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:oouchi_stock/i18n/app_localizations.dart';
 import 'presentation/viewmodels/edit_category_viewmodel.dart';
-import 'widgets/color_picker.dart';
 
 import 'domain/entities/category.dart';
 
@@ -42,17 +41,6 @@ class _EditCategoryPageState extends State<EditCategoryPage> {
                 decoration: InputDecoration(labelText: AppLocalizations.of(context)!.categoryName),
                 onChanged: (v) => _viewModel.name = v,
                 validator: (v) => v == null || v.isEmpty ? AppLocalizations.of(context)!.required : null,
-              ),
-              const SizedBox(height: 16),
-              Align(
-                alignment: Alignment.centerLeft,
-                child: Text(AppLocalizations.of(context)!.selectColor),
-              ),
-              // 共通ウィジェットで色を選択
-              ColorPicker(
-                colors: _viewModel.colors,
-                selected: _viewModel.color,
-                onSelected: (c) => setState(() => _viewModel.color = c),
               ),
               const SizedBox(height: 24),
               // 保存ボタンをタップしたときにカテゴリ名を更新

--- a/lib/presentation/viewmodels/edit_category_viewmodel.dart
+++ b/lib/presentation/viewmodels/edit_category_viewmodel.dart
@@ -19,26 +19,8 @@ class EditCategoryViewModel extends ChangeNotifier {
   /// カテゴリ名
   String name;
 
-  /// 選択中のカラー
-  Color? color;
-
-  /// 選択候補の色一覧
-  final List<Color> colors = const [
-    Colors.red,
-    Colors.green,
-    Colors.blue,
-    Colors.orange,
-    Colors.purple,
-    Colors.brown,
-    Colors.pink,
-    Colors.cyan,
-  ];
-
   EditCategoryViewModel(this.original)
-      : name = original.name,
-        color = original.color != null
-            ? Color(0xFF000000 | int.parse(original.color!.substring(1), radix: 16))
-            : null;
+      : name = original.name;
 
   /// 入力値を保存
   Future<void> save() async {
@@ -46,9 +28,8 @@ class EditCategoryViewModel extends ChangeNotifier {
       id: original.id,
       name: name,
       createdAt: original.createdAt,
-      color: color == null
-          ? null
-          : '#${color!.value.toRadixString(16).padLeft(8, '0').substring(2)}',
+      // 色は編集不可のため元の値を保持
+      color: original.color,
     );
     await _usecase(updated);
   }


### PR DESCRIPTION
## Summary
- カテゴリ編集画面で色を変更するUIを削除
- ViewModelも色関連の状態を除去

## Testing
- `flutter test` *(失敗: flutter コマンドなし)*

------
https://chatgpt.com/codex/tasks/task_e_687ae33aaf58832ea6e88ce437d49c08