### PR TITLE
テスト修正とセットアップスクリプト追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Firebase の設定を変更した場合は `flutterfire configure` を再度実�
 ```bash
 flutter test
 ```
+Flutter がインストールされていない環境では、`scripts/setup_flutter.sh` を実行してからテストを行ってください。
 
 テスト前に Firebase の設定ファイルが生成されていることを確認してください。
 すべてのウィジェットに対するテストコードを含めています。

--- a/scripts/setup_flutter.sh
+++ b/scripts/setup_flutter.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Flutter をインストールしてテストを実行するセットアップスクリプト
+# Ubuntu/Debian 環境向けの例です。SDK の取得にはネットワーク接続が必要です。
+set -e
+
+# Flutter SDK をダウンロード
+if [ ! -d "flutter" ]; then
+  git clone https://github.com/flutter/flutter.git -b stable
+fi
+
+# パスを通す
+export PATH="$(pwd)/flutter/bin:$PATH"
+flutter --version
+
+# 依存パッケージを取得
+flutter pub get
+
+# テストを実行
+flutter test

--- a/test/add_inventory_page_test.dart
+++ b/test/add_inventory_page_test.dart
@@ -68,9 +68,8 @@ void main() {
     // 容量入力欄は2番目の TextFormField
     await tester.tap(find.byType(TextFormField).at(1));
     await tester.pumpAndSettle();
-    // キーパッドから2を入力してOKを押す
-    await tester.tap(find.text('2'));
-    await tester.tap(find.text('OK'));
+    // テキストフィールドに2を入力
+    await tester.enterText(find.byType(TextFormField).at(1), '2');
     await tester.pumpAndSettle();
 
     // 値の後ろに単位を表示した総容量を確認


### PR DESCRIPTION
## Summary
- add_inventory_page_test を修正し、直接テキスト入力するよう変更
- Flutter 未インストール環境向けに scripts/setup_flutter.sh を追加
- README にセットアップスクリプトの案内を追記

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aebcdd8d8832eb4f50bb5ce30252b