### PR TITLE
リスト表示パフォーマンスの改善とテスト更新

### DIFF
--- a/lib/inventory_page.dart
+++ b/lib/inventory_page.dart
@@ -184,6 +184,12 @@ class _InventoryListState extends State<InventoryList> {
 
   @override
   Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    // 在庫一覧画面で検索や削除操作後のリストを再構成する
+    final items = _viewModel.filteredItems;
+    _removedIds.removeWhere((id) => items.every((e) => e.id != id));
+    final visible = items.where((e) => !_removedIds.contains(e.id)).toList();
+
     return CustomScrollView(
       slivers: [
         // 他画面と同じ検索バーを SliverToBoxAdapter で表示
@@ -198,121 +204,106 @@ class _InventoryListState extends State<InventoryList> {
             ),
           ),
         ),
-        StreamBuilder<List<Inventory>>(
-          stream: _viewModel.stream,
-          builder: (context, snapshot) {
-            if (snapshot.hasError) {
-              final err = snapshot.error?.toString() ?? 'unknown';
-              return SliverFillRemaining(
-                hasScrollBody: false,
-                child: Center(
-                  child: Text(AppLocalizations.of(context)!.loadError(err)),
-                ),
-              );
-            }
-            if (!snapshot.hasData) {
-              return const SliverFillRemaining(
-                hasScrollBody: false,
-                child: Center(child: CircularProgressIndicator()),
-              );
-            }
-            var list = snapshot.data!
-                .where((inv) =>
-                    inv.itemName.contains(_viewModel.search) ||
-                    inv.category.contains(_viewModel.search) ||
-                    inv.itemType.contains(_viewModel.search))
-                .toList();
-            _removedIds.removeWhere((id) => list.every((e) => e.id != id));
-            list = list.where((e) => !_removedIds.contains(e.id)).toList();
-            // 並び替え機能は廃止したため、常に最終更新日時順で表示
-            list.sort((a, b) => b.createdAt.compareTo(a.createdAt));
-            return SliverPadding(
-              padding: const EdgeInsets.all(16),
-              sliver: SliverList(
-                delegate: SliverChildBuilderDelegate(
-                  (context, index) {
-                    final inv = list[index];
-                    return Dismissible(
-                      key: ValueKey(inv.id),
-                      direction: DismissDirection.startToEnd,
-                      confirmDismiss: (_) async {
-                        final loc = AppLocalizations.of(context)!;
-                        final res = await showDialog<bool>(
-                          context: context,
-                          builder: (_) => AlertDialog(
-                            content: Text(loc.deleteConfirm),
-                            actions: [
-                              TextButton(
-                                onPressed: () => Navigator.pop(context, false),
-                                child: Text(loc.cancel),
-                              ),
-                              TextButton(
-                                onPressed: () => Navigator.pop(context, true),
-                                child: Text(loc.delete),
-                              ),
-                            ],
-                          ),
-                        );
-                        return res ?? false;
-                      },
-                      onDismissed: (_) async {
-                        setState(() {
-                          _removedIds.add(inv.id);
-                        });
-                        try {
-                          await _viewModel.delete(inv.id);
-                        } catch (e) {
-                          if (context.mounted) {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              SnackBar(
-                                content:
-                                    Text(AppLocalizations.of(context)!.deleteFailed),
-                              ),
-                            );
-                          }
-                        }
-                      },
-                      background: Container(
-                        color: Colors.red,
-                        alignment: Alignment.centerLeft,
-                        padding: const EdgeInsets.only(left: 16),
-                        child: const Icon(Icons.delete, color: Colors.white),
-                      ),
-                      child: InventoryCard(
-                        inventory: inv,
-                        updateQuantity: _viewModel.updateQuantity,
-                        stocktake: _viewModel.stocktake,
-                        onTap: () {
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (_) => InventoryDetailPage(
-                                inventoryId: inv.id,
-                                categories: widget.categories,
-                              ),
+        if (_viewModel.loading)
+          const SliverFillRemaining(
+            hasScrollBody: false,
+            child: Center(child: CircularProgressIndicator()),
+          )
+        else if (_viewModel.errorMessage != null)
+          SliverFillRemaining(
+            hasScrollBody: false,
+            child: Center(
+              child: Text(loc.loadError(_viewModel.errorMessage!)),
+            ),
+          )
+        else if (visible.isEmpty)
+          SliverFillRemaining(
+            hasScrollBody: false,
+            child: Center(child: Text(loc.noItems)),
+          )
+        else
+          SliverPadding(
+            padding: const EdgeInsets.all(16),
+            sliver: SliverList(
+              delegate: SliverChildBuilderDelegate(
+                (context, index) {
+                  final inv = visible[index];
+                  return Dismissible(
+                    key: ValueKey(inv.id),
+                    direction: DismissDirection.startToEnd,
+                    confirmDismiss: (_) async {
+                      final res = await showDialog<bool>(
+                        context: context,
+                        builder: (_) => AlertDialog(
+                          content: Text(loc.deleteConfirm),
+                          actions: [
+                            TextButton(
+                              onPressed: () => Navigator.pop(context, false),
+                              child: Text(loc.cancel),
+                            ),
+                            TextButton(
+                              onPressed: () => Navigator.pop(context, true),
+                              child: Text(loc.delete),
+                            ),
+                          ],
+                        ),
+                      );
+                      return res ?? false;
+                    },
+                    onDismissed: (_) async {
+                      setState(() {
+                        _removedIds.add(inv.id);
+                      });
+                      try {
+                        await _viewModel.delete(inv.id);
+                      } catch (e) {
+                        if (context.mounted) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text(loc.deleteFailed),
                             ),
                           );
-                        },
-                        onAddToList: () async {
-                          await _viewModel.addToBuyList(inv);
-                          if (mounted) {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              SnackBar(
-                                content: Text(
-                                    AppLocalizations.of(context)!.addedBuyItem),
-                              ),
-                            );
-                          }
-                        },
-                      ),
-                    );
-                  },
-                  childCount: list.length,
-                ),
+                        }
+                      }
+                    },
+                    background: Container(
+                      color: Colors.red,
+                      alignment: Alignment.centerLeft,
+                      padding: const EdgeInsets.only(left: 16),
+                      child: const Icon(Icons.delete, color: Colors.white),
+                    ),
+                    child: InventoryCard(
+                      inventory: inv,
+                      updateQuantity: _viewModel.updateQuantity,
+                      stocktake: _viewModel.stocktake,
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => InventoryDetailPage(
+                              inventoryId: inv.id,
+                              categories: widget.categories,
+                            ),
+                          ),
+                        );
+                      },
+                      onAddToList: () async {
+                        await _viewModel.addToBuyList(inv);
+                        if (mounted) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text(loc.addedBuyItem),
+                            ),
+                          );
+                        }
+                      },
+                    ),
+                  );
+                },
+                childCount: visible.length,
               ),
-            );
-          },
-        ),
+            ),
+          ),
       ],
     );
   }

--- a/lib/presentation/viewmodels/inventory_list_viewmodel.dart
+++ b/lib/presentation/viewmodels/inventory_list_viewmodel.dart
@@ -1,42 +1,51 @@
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-import '../../domain/entities/inventory.dart';
-import '../../domain/entities/buy_item.dart';
-import '../../domain/usecases/watch_inventories.dart';
-import '../../domain/usecases/delete_inventory_with_relations.dart';
-import '../../domain/usecases/add_buy_item.dart';
-import '../../domain/usecases/update_quantity.dart';
-import '../../domain/usecases/stocktake.dart';
-import '../../data/repositories/inventory_repository_impl.dart';
 import '../../data/repositories/buy_list_repository_impl.dart';
-import '../../data/repositories/price_repository_impl.dart';
 import '../../data/repositories/buy_prediction_repository_impl.dart';
+import '../../data/repositories/inventory_repository_impl.dart';
+import '../../data/repositories/price_repository_impl.dart';
+import '../../domain/entities/buy_item.dart';
+import '../../domain/entities/inventory.dart';
+import '../../domain/entities/purchase_decision_settings.dart';
+import '../../domain/usecases/add_buy_item.dart';
+import '../../domain/usecases/add_prediction_item.dart';
+import '../../domain/usecases/auto_add_buy_item.dart';
+import '../../domain/usecases/auto_add_prediction_item.dart';
+import '../../domain/usecases/delete_inventory_with_relations.dart';
+import '../../domain/usecases/purchase_decision.dart';
+import '../../domain/usecases/stocktake.dart';
+import '../../domain/usecases/update_quantity.dart';
+import '../../domain/usecases/watch_inventories.dart';
 import '../../domain/usecases/watch_inventory.dart';
 import '../../domain/usecases/watch_price_by_type.dart';
-import '../../domain/usecases/add_prediction_item.dart';
-import '../../domain/usecases/auto_add_prediction_item.dart';
-import '../../domain/usecases/auto_add_buy_item.dart';
-import '../../domain/usecases/purchase_decision.dart';
-import '../../domain/entities/purchase_decision_settings.dart';
 
 /// 在庫一覧の1タブ分の状態を管理する ViewModel
-/// 検索ワードを保持し、在庫データのストリームを提供する
+/// 検索バーやスワイプ削除など、在庫一覧画面の操作を集約する
 class InventoryListViewModel extends ChangeNotifier {
   /// 表示対象カテゴリ名
   final String category;
-  final WatchInventories watchUsecase =
-      WatchInventories(InventoryRepositoryImpl());
-  final DeleteInventoryWithRelations deleteUsecase = DeleteInventoryWithRelations(
-    InventoryRepositoryImpl(),
-    PriceRepositoryImpl(),
-    BuyListRepositoryImpl(),
-    BuyPredictionRepositoryImpl(),
-  );
-  final AddBuyItem addUsecase = AddBuyItem(BuyListRepositoryImpl());
-  final UpdateQuantity updateQuantityUsecase =
-      UpdateQuantity(InventoryRepositoryImpl());
-  final Stocktake stocktakeUsecase =
-      Stocktake(InventoryRepositoryImpl());
+
+  /// 在庫取得ユースケース
+  final WatchInventories _watch;
+
+  /// 在庫削除ユースケース
+  final DeleteInventoryWithRelations _delete;
+
+  /// 買い物リスト追加ユースケース
+  final AddBuyItem _addBuy;
+
+  /// 在庫数量更新ユースケース
+  final UpdateQuantity _updateQuantity;
+
+  /// 棚卸し登録ユースケース
+  final Stocktake _stocktake;
+
+  /// 検索・フィルタ処理のディレイ
+  final Duration _debounceDuration;
 
   /// 検索文字列
   String search = '';
@@ -44,31 +53,121 @@ class InventoryListViewModel extends ChangeNotifier {
   /// 検索バーのコントローラ
   final SearchController controller = SearchController();
 
-  InventoryListViewModel({required this.category});
+  /// 最新の取得結果
+  List<Inventory> _rawItems = const [];
 
-  /// 在庫ストリームを取得
-  Stream<List<Inventory>> get stream => watchUsecase(category);
+  /// フィルタ後の一覧
+  List<Inventory> _filteredItems = const [];
 
-  /// 検索文字列を更新
-  void setSearch(String value) {
-    search = value;
+  /// Firestore 取得中かどうか
+  bool _loading = true;
+
+  /// 読み込み失敗時のメッセージ
+  String? _errorMessage;
+
+  StreamSubscription<List<Inventory>>? _subscription;
+  Timer? _debounceTimer;
+
+  InventoryListViewModel({
+    required this.category,
+    WatchInventories? watch,
+    DeleteInventoryWithRelations? delete,
+    AddBuyItem? addBuy,
+    UpdateQuantity? updateQuantity,
+    Stocktake? stocktake,
+    Duration debounceDuration = const Duration(milliseconds: 160),
+  })  : _watch = watch ?? WatchInventories(InventoryRepositoryImpl()),
+        _delete = delete ??
+            DeleteInventoryWithRelations(
+              InventoryRepositoryImpl(),
+              PriceRepositoryImpl(),
+              BuyListRepositoryImpl(),
+              BuyPredictionRepositoryImpl(),
+            ),
+        _addBuy = addBuy ?? AddBuyItem(BuyListRepositoryImpl()),
+        _updateQuantity = updateQuantity ?? UpdateQuantity(InventoryRepositoryImpl()),
+        _stocktake = stocktake ?? Stocktake(InventoryRepositoryImpl()),
+        _debounceDuration = debounceDuration {
+    _startWatch();
+  }
+
+  /// 表示用の在庫リスト
+  UnmodifiableListView<Inventory> get filteredItems =>
+      UnmodifiableListView(_filteredItems);
+
+  /// データ取得中かどうか
+  bool get loading => _loading;
+
+  /// エラー文言
+  String? get errorMessage => _errorMessage;
+
+  void _startWatch() {
+    _subscription?.cancel();
+    _loading = true;
+    _errorMessage = null;
+    notifyListeners();
+    _subscription = _watch(category).listen(
+      (items) {
+        _rawItems = items;
+        _loading = false;
+        _errorMessage = null;
+        _applyFilters(immediate: true);
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        _loading = false;
+        _errorMessage = error.toString();
+        notifyListeners();
+      },
+    );
+  }
+
+  void _applyFilters({bool immediate = false}) {
+    if (!immediate) {
+      _debounceTimer?.cancel();
+      _debounceTimer = Timer(_debounceDuration, () => _applyFilters(immediate: true));
+      return;
+    }
+
+    final query = search.trim().toLowerCase();
+    final filtered = _rawItems.where((inv) {
+      if (query.isEmpty) {
+        return true;
+      }
+      return inv.itemName.toLowerCase().contains(query) ||
+          inv.category.toLowerCase().contains(query) ||
+          inv.itemType.toLowerCase().contains(query);
+    }).toList()
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+
+    if (!listEquals(filtered, _filteredItems)) {
+      _filteredItems = filtered;
+    }
     notifyListeners();
   }
 
+  /// 在庫一覧画面の検索バーから呼び出される
+  void setSearch(String value) {
+    search = value;
+    _applyFilters();
+  }
 
   /// 在庫を買い物リストへ追加
   Future<void> addToBuyList(Inventory inv) async {
-    await addUsecase(
-        BuyItem(inv.itemName, inv.category, inv.id, BuyItemReason.inventory));
+    await _addBuy(
+      BuyItem(inv.itemName, inv.category, inv.id, BuyItemReason.inventory),
+    );
   }
 
   /// 在庫数量を更新
   Future<void> updateQuantity(String id, double amount, String type) async {
-    await updateQuantityUsecase(id, amount, type);
+    await _updateQuantity(id, amount, type);
     try {
       final inv = await WatchInventory(InventoryRepositoryImpl())(id).first;
       if (inv == null) return;
-      final prices = await WatchPriceByType(PriceRepositoryImpl())(inv.category, inv.itemType).first;
+      final prices = await WatchPriceByType(PriceRepositoryImpl())(
+        inv.category,
+        inv.itemType,
+      ).first;
       final price = prices.isNotEmpty ? prices.first : null;
       final settings = await loadPurchaseDecisionSettings();
       final prediction = AutoAddPredictionItem(
@@ -99,12 +198,20 @@ class InventoryListViewModel extends ChangeNotifier {
   }
 
   /// 棚卸しを記録
-  Future<void> stocktake(String id, double before, double after, double diff) async {
-    await stocktakeUsecase(id, before, after, diff);
+  Future<void> stocktake(
+    String id,
+    double before,
+    double after,
+    double diff,
+  ) async {
+    await _stocktake(id, before, after, diff);
     try {
       final inv = await WatchInventory(InventoryRepositoryImpl())(id).first;
       if (inv == null) return;
-      final prices = await WatchPriceByType(PriceRepositoryImpl())(inv.category, inv.itemType).first;
+      final prices = await WatchPriceByType(PriceRepositoryImpl())(
+        inv.category,
+        inv.itemType,
+      ).first;
       final price = prices.isNotEmpty ? prices.first : null;
       final settings = await loadPurchaseDecisionSettings();
       final prediction = AutoAddPredictionItem(
@@ -135,11 +242,13 @@ class InventoryListViewModel extends ChangeNotifier {
 
   /// 在庫を削除
   Future<void> delete(String id) async {
-    await deleteUsecase(id);
+    await _delete(id);
   }
 
   @override
   void dispose() {
+    _debounceTimer?.cancel();
+    _subscription?.cancel();
     controller.dispose();
     super.dispose();
   }

--- a/lib/presentation/viewmodels/price_category_list_viewmodel.dart
+++ b/lib/presentation/viewmodels/price_category_list_viewmodel.dart
@@ -1,30 +1,33 @@
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import '../../data/repositories/price_repository_impl.dart';
-import '../../domain/entities/price_info.dart';
-import '../../domain/usecases/watch_price_by_category.dart';
-import '../../domain/usecases/delete_price_info.dart';
-import '../../domain/usecases/add_buy_item.dart';
+
 import '../../data/repositories/buy_list_repository_impl.dart';
+import '../../data/repositories/price_repository_impl.dart';
 import '../../domain/entities/buy_item.dart';
+import '../../domain/entities/price_info.dart';
+import '../../domain/usecases/add_buy_item.dart';
+import '../../domain/usecases/delete_price_info.dart';
+import '../../domain/usecases/watch_price_by_category.dart';
 
 /// セール情報管理画面のカテゴリタブを管理する ViewModel
 class PriceCategoryListViewModel extends ChangeNotifier {
   /// 対象カテゴリ名
   final String category;
+
   /// セール情報監視用ユースケース
   final WatchPriceByCategory _watch;
+
   /// セール情報削除用ユースケース
   final DeletePriceInfo _delete;
+
   /// 買い物リスト追加ユースケース
   final AddBuyItem _addBuy;
 
-  PriceCategoryListViewModel({
-    required this.category,
-    WatchPriceByCategory? watch,
-    DeletePriceInfo? delete,
-  })  : _watch = watch ?? WatchPriceByCategory(PriceRepositoryImpl()),
-        _delete = delete ?? DeletePriceInfo(PriceRepositoryImpl()),
-        _addBuy = AddBuyItem(BuyListRepositoryImpl());
+  /// フィルタリングを遅延させる待ち時間
+  final Duration _debounceDuration;
 
   /// 検索文字列
   String search = '';
@@ -38,25 +41,120 @@ class PriceCategoryListViewModel extends ChangeNotifier {
   /// 入力コントローラー
   final SearchController controller = SearchController();
 
-  /// セール情報ストリーム
-  Stream<List<PriceInfo>> get stream => _watch(category);
+  /// 最新の取得結果
+  List<PriceInfo> _rawItems = const [];
 
-  /// 検索文字列を更新
+  /// フィルタ後の一覧
+  List<PriceInfo> _filteredItems = const [];
+
+  /// Firestore 取得中かどうか
+  bool _loading = true;
+
+  /// エラーメッセージ
+  String? _errorMessage;
+
+  StreamSubscription<List<PriceInfo>>? _subscription;
+  Timer? _debounceTimer;
+
+  PriceCategoryListViewModel({
+    required this.category,
+    WatchPriceByCategory? watch,
+    DeletePriceInfo? delete,
+    AddBuyItem? addBuy,
+    Duration debounceDuration = const Duration(milliseconds: 160),
+  })  : _watch = watch ?? WatchPriceByCategory(PriceRepositoryImpl()),
+        _delete = delete ?? DeletePriceInfo(PriceRepositoryImpl()),
+        _addBuy = addBuy ?? AddBuyItem(BuyListRepositoryImpl()),
+        _debounceDuration = debounceDuration {
+    _startWatch();
+  }
+
+  /// 表示用の一覧を取得
+  UnmodifiableListView<PriceInfo> get filteredItems =>
+      UnmodifiableListView(_filteredItems);
+
+  /// データ取得中かどうか
+  bool get loading => _loading;
+
+  /// 読み込みエラー内容
+  String? get errorMessage => _errorMessage;
+
+  void _startWatch() {
+    _subscription?.cancel();
+    _loading = true;
+    _errorMessage = null;
+    notifyListeners();
+    _subscription = _watch(category).listen(
+      (items) {
+        _rawItems = items;
+        _loading = false;
+        _errorMessage = null;
+        _applyFilters(immediate: true);
+      },
+      onError: (Object error, StackTrace stack) {
+        _loading = false;
+        _errorMessage = error.toString();
+        notifyListeners();
+      },
+    );
+  }
+
+  void _applyFilters({bool immediate = false}) {
+    if (!immediate) {
+      _debounceTimer?.cancel();
+      _debounceTimer = Timer(_debounceDuration, () => _applyFilters(immediate: true));
+      return;
+    }
+
+    final now = DateTime.now();
+    final query = search.trim().toLowerCase();
+    final filtered = _rawItems.where((info) {
+      if (!showExpired && info.expiry
+          .isBefore(now.subtract(const Duration(days: 1)))) {
+        return false;
+      }
+      if (query.isEmpty) {
+        return true;
+      }
+      return info.itemName.toLowerCase().contains(query) ||
+          info.category.toLowerCase().contains(query) ||
+          info.itemType.toLowerCase().contains(query);
+    }).toList();
+
+    switch (sort) {
+      case 'alphabet':
+        filtered.sort((a, b) => a.itemType.compareTo(b.itemType));
+        break;
+      case 'unitPrice':
+        filtered.sort((a, b) => a.unitPrice.compareTo(b.unitPrice));
+        break;
+      default:
+        filtered.sort((a, b) => b.checkedAt.compareTo(a.checkedAt));
+        break;
+    }
+
+    if (!listEquals(filtered, _filteredItems)) {
+      _filteredItems = filtered;
+    }
+    notifyListeners();
+  }
+
+  /// セール情報管理画面の検索バーから呼び出される
   void setSearch(String v) {
     search = v;
-    notifyListeners();
+    _applyFilters();
   }
 
   /// 並び替え条件を更新
   void setSort(String v) {
     sort = v;
-    notifyListeners();
+    _applyFilters(immediate: true);
   }
 
   /// 期限切れ表示設定を更新
   void setShowExpired(bool v) {
     showExpired = v;
-    notifyListeners();
+    _applyFilters(immediate: true);
   }
 
   /// セール情報を削除
@@ -73,6 +171,8 @@ class PriceCategoryListViewModel extends ChangeNotifier {
 
   @override
   void dispose() {
+    _debounceTimer?.cancel();
+    _subscription?.cancel();
     controller.dispose();
     super.dispose();
   }

--- a/lib/price_list_page.dart
+++ b/lib/price_list_page.dart
@@ -213,157 +213,8 @@ class _PriceCategoryListState extends State<PriceCategoryList> {
         Expanded(
           child: Stack(
             children: [
-              StreamBuilder<List<PriceInfo>>(
-                stream: _viewModel.stream,
-                builder: (context, snapshot) {
-              if (snapshot.hasError) {
-                final err = snapshot.error?.toString() ?? 'unknown';
-                return Center(child: Text(AppLocalizations.of(context)!.loadError(err)));
-              }
-              if (!snapshot.hasData) {
-                return const Center(child: CircularProgressIndicator());
-              }
-              // Firestoreから取得した最新データ
-              var items = snapshot.data!
-                  .where((e) => e.itemName.contains(_viewModel.search) ||
-                      e.category.contains(_viewModel.search) ||
-                      e.itemType.contains(_viewModel.search))
-                  .where((e) => _viewModel.showExpired || e.expiry.isAfter(DateTime.now().subtract(const Duration(days: 1))))
-                  .toList();
-              // Firestore側で削除完了したIDは一覧から除外
-              _removedIds.removeWhere((id) => items.every((e) => e.id != id));
-              // スワイプ直後に除外したIDも非表示にする
-              items = items.where((e) => !_removedIds.contains(e.id)).toList();
-              if (_viewModel.sort == 'alphabet') {
-                items.sort((a, b) => a.itemType.compareTo(b.itemType));
-              } else if (_viewModel.sort == 'unitPrice') {
-                items.sort((a, b) => a.unitPrice.compareTo(b.unitPrice));
-              } else {
-                items.sort((a, b) => b.checkedAt.compareTo(a.checkedAt));
-              }
-                  // セール情報管理画面のリスト表示部分
-                  // 検索バーとの余白を統一するため左右16、上16を指定
-                  return ListView.builder(
-                    padding: const EdgeInsets.fromLTRB(16, 16, 16, 96),
-                    itemCount: items.length,
-                    itemBuilder: (context, index) {
-                  final p = items[index];
-                  // セール価格と通常価格の差額（正負をそのまま表示）
-                  final diff = p.salePrice - p.regularPrice;
-                  final diffStr = diff > 0
-                      ? '+${diff.toStringAsFixed(0)}'
-                      : diff.toStringAsFixed(0);
-                  return Dismissible(
-                    key: ValueKey(p.id),
-                    direction: DismissDirection.startToEnd,
-                    // スワイプ時に削除確認ダイアログを表示
-                    confirmDismiss: (_) async {
-                      final loc = AppLocalizations.of(context)!;
-                      final res = await showDialog<bool>(
-                        context: context,
-                        builder: (_) => AlertDialog(
-                          content: Text(loc.deleteConfirm),
-                          actions: [
-                            TextButton(
-                              onPressed: () => Navigator.pop(context, false),
-                              child: Text(loc.cancel),
-                            ),
-                            TextButton(
-                              onPressed: () => Navigator.pop(context, true),
-                              child: Text(loc.delete),
-                            ),
-                          ],
-                        ),
-                      );
-                      return res ?? false;
-                    },
-                    // 削除処理本体
-                    onDismissed: (_) async {
-                      setState(() {
-                        // Dismissible アニメーション完了後に残らないようIDを記録
-                        _removedIds.add(p.id);
-                      });
-                      try {
-                        await _viewModel.delete(p.id);
-                        if (mounted) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(content: Text(AppLocalizations.of(context)!.deleted)),
-                          );
-                        }
-                      } catch (_) {
-                        if (mounted) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(content: Text(AppLocalizations.of(context)!.deleteFailed)),
-                          );
-                        }
-                      }
-                    },
-                    background: Container(
-                      color: Colors.red,
-                      alignment: Alignment.centerLeft,
-                      padding: const EdgeInsets.only(left: 16),
-                      child: const Icon(Icons.delete, color: Colors.white),
-                    ),
-                    child: Card(
-                      margin: const EdgeInsets.symmetric(vertical: 8),
-                      child: InkWell(
-                        // カードタップでセール詳細画面へ遷移
-                        onTap: () {
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(builder: (_) => PriceDetailPage(info: p)),
-                          );
-                        },
-                        child: Padding(
-                          // 価格情報とメニューを右側に配置し、商品名の領域を拡大する
-                          padding: const EdgeInsets.all(16),
-                          child: Row(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              // 商品名と品種を左側にまとめて表示するエリア
-                              Expanded(
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    ScrollingText(
-                                      '${p.itemName} / ${p.itemType}',
-                                      style: Theme.of(context).textTheme.titleMedium,
-                                    ),
-                                    const SizedBox(height: 4),
-                                    Text(
-                                      AppLocalizations.of(context)!.expiry(_formatDate(p.expiry)),
-                                      style: Theme.of(context).textTheme.bodyMedium,
-                                    ),
-                                  ],
-                                ),
-                              ),
-                              const SizedBox(width: 8),
-                              // 右側に価格情報を縦並びで表示する
-                              Column(
-                                mainAxisSize: MainAxisSize.min,
-                                crossAxisAlignment: CrossAxisAlignment.end,
-                                children: [
-                                  Text(
-                                    '${AppLocalizations.of(context)!.regularPriceLabel(p.regularPrice.toStringAsFixed(0))} '
-                                    '${AppLocalizations.of(context)!.salePriceLabel(p.salePrice.toStringAsFixed(0))} '
-                                    '${AppLocalizations.of(context)!.priceDiffLabel(diffStr)}',
-                                  ),
-                                  Text(AppLocalizations.of(context)!.unitPrice(p.unitPrice.toStringAsFixed(2))),
-                                ],
-                              ),
-                              // メニューボタンを価格情報の右端に配置
-                              CardMenuButton(
-                                onPressed: () => _showActions(context, p),
-                              ),
-                            ],
-                          ),
-                        ),
-                      ),
-                    ),
-                  );
-                },
-                  );
-                },
+              Positioned.fill(
+                child: _buildListContent(context),
               ),
               Align(
                 alignment: Alignment.bottomCenter,
@@ -373,6 +224,148 @@ class _PriceCategoryListState extends State<PriceCategoryList> {
           ),
         ),
       ],
+    );
+  }
+
+  /// セール情報管理画面のリスト本体。
+  /// 取得状況に応じてローディングやエラー表示を切り替える
+  Widget _buildListContent(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    if (_viewModel.loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_viewModel.errorMessage != null) {
+      return Center(child: Text(loc.loadError(_viewModel.errorMessage!)));
+    }
+    final items = _viewModel.filteredItems;
+    // Firestore側で削除完了したIDは一覧から除外
+    _removedIds.removeWhere((id) => items.every((e) => e.id != id));
+    // スワイプ直後に除外したIDも非表示にする
+    final visible = items.where((e) => !_removedIds.contains(e.id)).toList();
+    if (visible.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.only(bottom: 96),
+        child: Center(child: Text(loc.noItems)),
+      );
+    }
+    return ListView.builder(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 96),
+      itemCount: visible.length,
+      itemBuilder: (context, index) {
+        final p = visible[index];
+        // セール価格と通常価格の差額（正負をそのまま表示）
+        final diff = p.salePrice - p.regularPrice;
+        final diffStr = diff > 0
+            ? '+${diff.toStringAsFixed(0)}'
+            : diff.toStringAsFixed(0);
+        return Dismissible(
+          key: ValueKey(p.id),
+          direction: DismissDirection.startToEnd,
+          // スワイプ時に削除確認ダイアログを表示
+          confirmDismiss: (_) async {
+            final loc = AppLocalizations.of(context)!;
+            final res = await showDialog<bool>(
+              context: context,
+              builder: (_) => AlertDialog(
+                content: Text(loc.deleteConfirm),
+                actions: [
+                  TextButton(
+                    onPressed: () => Navigator.pop(context, false),
+                    child: Text(loc.cancel),
+                  ),
+                  TextButton(
+                    onPressed: () => Navigator.pop(context, true),
+                    child: Text(loc.delete),
+                  ),
+                ],
+              ),
+            );
+            return res ?? false;
+          },
+          // 削除処理本体
+          onDismissed: (_) async {
+            setState(() {
+              // Dismissible アニメーション完了後に残らないようIDを記録
+              _removedIds.add(p.id);
+            });
+            try {
+              await _viewModel.delete(p.id);
+              if (mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text(AppLocalizations.of(context)!.deleted)),
+                );
+              }
+            } catch (_) {
+              if (mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text(AppLocalizations.of(context)!.deleteFailed)),
+                );
+              }
+            }
+          },
+          background: Container(
+            color: Colors.red,
+            alignment: Alignment.centerLeft,
+            padding: const EdgeInsets.only(left: 16),
+            child: const Icon(Icons.delete, color: Colors.white),
+          ),
+          child: Card(
+            margin: const EdgeInsets.symmetric(vertical: 8),
+            child: InkWell(
+              // カードタップでセール詳細画面へ遷移
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => PriceDetailPage(info: p)),
+                );
+              },
+              child: Padding(
+                // 価格情報とメニューを右側に配置し、商品名の領域を拡大する
+                padding: const EdgeInsets.all(16),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // 商品名と品種を左側にまとめて表示するエリア
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          ScrollingText(
+                            '${p.itemName} / ${p.itemType}',
+                            style: Theme.of(context).textTheme.titleMedium,
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            AppLocalizations.of(context)!.expiry(_formatDate(p.expiry)),
+                            style: Theme.of(context).textTheme.bodyMedium,
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    // 右側に価格情報を縦並びで表示する
+                    Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      children: [
+                        Text(
+                          '${AppLocalizations.of(context)!.regularPriceLabel(p.regularPrice.toStringAsFixed(0))} '
+                          '${AppLocalizations.of(context)!.salePriceLabel(p.salePrice.toStringAsFixed(0))} '
+                          '${AppLocalizations.of(context)!.priceDiffLabel(diffStr)}',
+                        ),
+                        Text(AppLocalizations.of(context)!.unitPrice(p.unitPrice.toStringAsFixed(2))),
+                      ],
+                    ),
+                    // メニューボタンを価格情報の右端に配置
+                    CardMenuButton(
+                      onPressed: () => _showActions(context, p),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+      },
     );
   }
 

--- a/lib/widgets/scrolling_text.dart
+++ b/lib/widgets/scrolling_text.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 
 /// 長いテキストを横スクロールさせるウィジェット
@@ -15,48 +17,122 @@ class ScrollingText extends StatefulWidget {
 class _ScrollingTextState extends State<ScrollingText>
     with SingleTickerProviderStateMixin {
   late final ScrollController _scrollController;
-  late final AnimationController _animation;
+  AnimationController? _animation;
   Timer? _startTimer;
+  double _overflowWidth = 0;
+  String _lastText = '';
+  double _lastMaxWidth = 0;
 
   @override
   void initState() {
     super.initState();
     _scrollController = ScrollController();
-    _animation =
-        AnimationController(vsync: this, duration: const Duration(seconds: 5))
-          ..addListener(() {
-            if (!_scrollController.hasClients) return;
-            final max = _scrollController.position.maxScrollExtent;
-            _scrollController.jumpTo(max * _animation.value);
-          })
-          ..addStatusListener((status) {
-            if (status == AnimationStatus.completed) {
-              _animation.reverse();
-            }
-          });
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _startTimer =
-          Timer(const Duration(seconds: 3), () => _animation.forward());
-    });
+  }
+
+  @override
+  void didUpdateWidget(covariant ScrollingText oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.text != widget.text) {
+      _lastText = '';
+    }
   }
 
   @override
   void dispose() {
-    _startTimer?.cancel();
-    _animation.dispose();
+    _stopAnimation();
     _scrollController.dispose();
     super.dispose();
   }
 
+  /// スクロールアニメーションを開始する。画面表示名が長い場合のみ呼ばれる
+  void _startAnimation() {
+    if (_overflowWidth <= 0 || !mounted) {
+      return;
+    }
+    _animation ??= AnimationController(
+      vsync: this,
+      duration: Duration(
+        // 文字列長に合わせてスクロール速度を一定化する（約70px/秒）
+        milliseconds: max((_overflowWidth / 70 * 1000).round(), 1500),
+      ),
+    )
+      ..addListener(() {
+        if (_scrollController.hasClients) {
+          _scrollController.jumpTo(_overflowWidth * _animation!.value);
+        }
+      })
+      ..addStatusListener((status) {
+        if (status == AnimationStatus.completed) {
+          _animation?.reverse();
+        } else if (status == AnimationStatus.dismissed) {
+          _animation?.forward();
+        }
+      });
+
+    if (_animation!.isAnimating) {
+      return;
+    }
+    _startTimer?.cancel();
+    // 画面表示直後に激しく動かないよう1秒待機してから開始
+    _startTimer = Timer(const Duration(seconds: 1), () {
+      if (mounted) {
+        _animation?.forward();
+      }
+    });
+  }
+
+  /// アニメーションを停止して位置をリセットする
+  void _stopAnimation() {
+    _startTimer?.cancel();
+    _animation?.stop();
+    _animation?.dispose();
+    _animation = null;
+    if (_scrollController.hasClients) {
+      _scrollController.jumpTo(0);
+    }
+  }
+
+  /// 表示領域とテキスト長からスクロールの要否を判定する
+  void _evaluateOverflow(BoxConstraints constraints) {
+    if (_lastText == widget.text && _lastMaxWidth == constraints.maxWidth) {
+      return;
+    }
+    _lastText = widget.text;
+    _lastMaxWidth = constraints.maxWidth;
+
+    final painter = TextPainter(
+      text: TextSpan(text: widget.text, style: widget.style),
+      maxLines: 1,
+      textDirection: Directionality.of(context),
+    )..layout(minWidth: 0, maxWidth: double.infinity);
+
+    final overflow = painter.width - constraints.maxWidth;
+    if (overflow <= 0) {
+      _overflowWidth = 0;
+      _stopAnimation();
+    } else {
+      _overflowWidth = overflow;
+      _startAnimation();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    return ClipRect(
-      child: SingleChildScrollView(
-        scrollDirection: Axis.horizontal,
-        controller: _scrollController,
-        physics: const NeverScrollableScrollPhysics(),
-        child: Text(widget.text, style: widget.style),
-      ),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          _evaluateOverflow(constraints);
+        });
+        return ClipRect(
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            controller: _scrollController,
+            physics: const NeverScrollableScrollPhysics(),
+            child: Text(widget.text, style: widget.style),
+          ),
+        );
+      },
     );
   }
 }

--- a/test/price_list_page_test.dart
+++ b/test/price_list_page_test.dart
@@ -35,6 +35,7 @@ void main() {
       ),
     ));
     await tester.pump();
+    await tester.pump();
     expect(find.byType(Card), findsWidgets);
   });
 
@@ -51,6 +52,7 @@ void main() {
       ),
     ));
     await tester.pump();
+    await tester.pump();
     expect(find.byType(Card), findsNWidgets(2));
   });
 
@@ -65,6 +67,7 @@ void main() {
         ),
       ),
     ));
+    await tester.pump();
     await tester.pump();
     await tester.tap(find.byType(InkWell).first);
     await tester.pumpAndSettle();
@@ -82,6 +85,7 @@ void main() {
         ),
       ),
     ));
+    await tester.pump();
     await tester.pump();
     expect(find.byType(Dismissible), findsWidgets);
   });
@@ -120,6 +124,7 @@ void main() {
       ),
     ));
     await tester.pump();
+    await tester.pump();
     await tester.tap(find.byIcon(Icons.more_vert));
     await tester.pumpAndSettle();
     expect(find.text('買い物リストへ追加'), findsOneWidget);
@@ -140,6 +145,7 @@ void main() {
       ),
     ));
     await tester.pump();
+    await tester.pump();
     expect(find.text('通常価格: 200 セール価格: 150 差額: -50'), findsOneWidget);
     expect(find.text('単価: 150.00'), findsOneWidget);
   });
@@ -159,6 +165,7 @@ void main() {
       ),
     ));
     await tester.pump();
+    await tester.pump();
     expect(find.text('商品A'), findsOneWidget);
 
     await tester.pumpWidget(MaterialApp(
@@ -171,6 +178,7 @@ void main() {
         ),
       ),
     ));
+    await tester.pump();
     await tester.pump();
     expect(find.text('商品B'), findsOneWidget);
   });
@@ -186,6 +194,7 @@ void main() {
         ),
       ),
     ));
+    await tester.pump();
     await tester.pump();
     final listView = tester.widget<ListView>(find.byType(ListView));
     expect(listView.padding, const EdgeInsets.fromLTRB(16, 16, 16, 96));


### PR DESCRIPTION
## 概要
- セール情報管理と在庫一覧の ViewModel でフィルタリング結果を保持し、ローディングやエラー表示を扱うように変更
- 画面側のリスト描画をリファクタリングして空表示を追加し、スクロールの描画負荷を軽減
- ScrollingText を必要時のみアニメーションする実装に差し替え
- 遅延読込に合わせて関連ウィジェットテストを調整

## 動作確認
- flutter test (コマンドが存在しないため失敗)

------
https://chatgpt.com/codex/tasks/task_e_68d138f95fb8832eaf521af175c90d56