### PR TITLE
Dismissibleの子ウィジェット定義の括弧誤りを修正

### DIFF
--- a/lib/price_list_page.dart
+++ b/lib/price_list_page.dart
@@ -364,8 +364,9 @@ class _PriceCategoryListState extends State<PriceCategoryList> {
                 ),
               ),
             ),
-          );
-        },
+          ),
+        );
+      },
     );
   }
 


### PR DESCRIPTION
## 概要
- Dismissibleウィジェットのchild定義で誤っていた括弧を修正し、ビルドエラーを解消

## テスト
- `flutter test`（Flutterが環境に存在しないため失敗）

------
https://chatgpt.com/codex/tasks/task_e_68d169024224832e8d4feaa6e6ae6203